### PR TITLE
Add requires threads in case of `mt` predicate

### DIFF
--- a/META
+++ b/META
@@ -6,6 +6,7 @@ archive(byte) = "lablgtk.cma"
 archive(native) = "lablgtk.cmxa"
 archive(byte,mt) += "gtkThread.cmo"
 archive(native,mt) += "gtkThread.cmx"
+requires(mt) += "threads"
 
 package "auto-init" (
   exists_if = "gtkInit.cmo,gtkInit.cmx"


### PR DESCRIPTION
It is working without that because findlib has a fixup/hack for that. It adds to all the library a dependency to threads when mt is used. In dune there is no hack, so users have strange error if they write `(libraries lablgtk threads)` or `(libraries lablgtk)` instead of `(libraries threads lablgtk)`.