### PR TITLE
Add supports for declaring message and question boxes transient for a parent

### DIFF
--- a/src/gToolbox.ml
+++ b/src/gToolbox.ml
@@ -70,9 +70,9 @@ let popup_menu ~entries =
 let mOk = "Ok"
 let mCancel = "Cancel"
 
-let question_box ~title  ~buttons ?(default=1) ?icon message =
+let question_box ?parent ?destroy_with_parent ~title  ~buttons ?(default=1) ?icon message =
   let button_nb = ref 0 in
-  let window = GWindow.dialog ~modal:true ~title () in
+  let window = GWindow.dialog ?parent ?destroy_with_parent ~modal:true ~title () in
   let hbox = GPack.hbox ~border_width:10 ~packing:window#vbox#add () in
   let bbox = window#action_area in
   begin match icon with
@@ -103,8 +103,8 @@ let question_box ~title  ~buttons ?(default=1) ?icon message =
   !button_nb
 
 
-let message_box ~title ?icon ?(ok=mOk) message =
-  ignore (question_box ?icon ~title message ~buttons:[ ok ])
+let message_box ?parent ?destroy_with_parent ~title ?icon ?(ok=mOk) message =
+  ignore (question_box ?parent ?destroy_with_parent ?icon ~title message ~buttons:[ ok ])
 
 
 let input_widget ~widget ~event ~get_text ~bind_ok ~expand

--- a/src/gToolbox.mli
+++ b/src/gToolbox.mli
@@ -47,6 +47,8 @@ val popup_menu : entries: menu_entry list -> button: int -> time: int32 -> unit
    with a parametrized list of buttons. The function returns the number
    of the clicked button (starting at 1), or 0 if the window is 
    savagedly destroyed.
+   @param parent the parent window in the front of which it should be displayed
+   @param destroy_with_parent relevant when the box has a parent (default is false)
    @param title the title of the dialog
    @param buttons the list of button labels.
    @param default the index of the default answer
@@ -55,12 +57,16 @@ val popup_menu : entries: menu_entry list -> button: int -> time: int32 -> unit
    @param message the text to display
 *)
 val question_box :
+    ?parent:#GWindow.window_skel ->
+    ?destroy_with_parent:bool ->
     title:string ->
     buttons:string list ->
     ?default:int -> ?icon:#GObj.widget -> string -> int
 
 (**This function is used to display a message in a dialog box with just an Ok button.
    We use [question_box] with just an ok button.
+   @param parent the parent window in the front of which it should be displayed
+   @param destroy_with_parent relevant when the box has a parent (default is false)
    @param title the title of the dialog
    @param icon a widget (usually a pixmap) which can be displayed on the left
      of the window.
@@ -68,6 +74,7 @@ val question_box :
    @param message the text to display
 *)
 val message_box :
+    ?parent:#GWindow.window_skel -> ?destroy_with_parent:bool ->
     title:string -> ?icon:#GObj.widget -> ?ok:string -> string -> unit
 
 (** Make the user type in a string. 


### PR DESCRIPTION
In CoqIDE, we use message and question boxes but, when switching between applications, they easily get lost behind the main window, while still blocking actions on the main window. Attaching such a box to a main window with gtk's `gtk_window_set_transient_for` would solve this problem.

This PR adds an optional parameter to `GToolbox.message_box` and `GToolbox.question_box` to indicate a parent to which to be attached. To be consistent, it also adds a `destroy_with_parent` parameter, though it is unclear that this would is the best design choice. Maybe, for simplicity, passing a parent should force `destroy_with_parent` to be set to true by default?

It is also unclear whether `parent` should be added to the other tool boxes (`tree_selection_dialog`, `input_widget`). I can extend the PR to them if there is a request for it.
