### PR TITLE
Extended supports for declaring boxes transient for a parent

### DIFF
--- a/src/gToolbox.ml
+++ b/src/gToolbox.ml
@@ -70,9 +70,9 @@ let popup_menu ~entries =
 let mOk = "Ok"
 let mCancel = "Cancel"
 
-let question_box ~title  ~buttons ?(default=1) ?icon message =
+let question_box ?parent ?destroy_with_parent ~title  ~buttons ?(default=1) ?icon message =
   let button_nb = ref 0 in
-  let window = GWindow.dialog ~modal:true ~title () in
+  let window = GWindow.dialog ?parent ?destroy_with_parent ~modal:true ~title () in
   let hbox = GPack.hbox ~border_width:10 ~packing:window#vbox#add () in
   let bbox = window#action_area in
   begin match icon with
@@ -103,8 +103,8 @@ let question_box ~title  ~buttons ?(default=1) ?icon message =
   !button_nb
 
 
-let message_box ~title ?icon ?(ok=mOk) message =
-  ignore (question_box ?icon ~title message ~buttons:[ ok ])
+let message_box ?parent ?destroy_with_parent ~title ?icon ?(ok=mOk) message =
+  ignore (question_box ?parent ?destroy_with_parent ?icon ~title message ~buttons:[ ok ])
 
 
 let input_widget ~widget ~event ~get_text ~bind_ok ~expand

--- a/src/gToolbox.mli
+++ b/src/gToolbox.mli
@@ -47,6 +47,8 @@ val popup_menu : entries: menu_entry list -> button: int -> time: int32 -> unit
    with a parametrized list of buttons. The function returns the number
    of the clicked button (starting at 1), or 0 if the window is 
    savagedly destroyed.
+   @param parent the parent window in the front of which it should be displayed
+   @param destroy_with_parent relevant when the box has a parent (default is false)
    @param title the title of the dialog
    @param buttons the list of button labels.
    @param default the index of the default answer
@@ -55,12 +57,16 @@ val popup_menu : entries: menu_entry list -> button: int -> time: int32 -> unit
    @param message the text to display
 *)
 val question_box :
+    ?parent:#GWindow.window_skel ->
+    ?destroy_with_parent:bool ->
     title:string ->
     buttons:string list ->
     ?default:int -> ?icon:#GObj.widget -> string -> int
 
 (**This function is used to display a message in a dialog box with just an Ok button.
    We use [question_box] with just an ok button.
+   @param parent the parent window in the front of which it should be displayed
+   @param destroy_with_parent relevant when the box has a parent (default is false)
    @param title the title of the dialog
    @param icon a widget (usually a pixmap) which can be displayed on the left
      of the window.
@@ -68,6 +74,7 @@ val question_box :
    @param message the text to display
 *)
 val message_box :
+    ?parent:#GWindow.window_skel -> ?destroy_with_parent:bool ->
     title:string -> ?icon:#GObj.widget -> ?ok:string -> string -> unit
 
 (** Make the user type in a string. 

--- a/src/gToolbox.mli
+++ b/src/gToolbox.mli
@@ -48,7 +48,6 @@ val popup_menu : entries: menu_entry list -> button: int -> time: int32 -> unit
    of the clicked button (starting at 1), or 0 if the window is 
    savagedly destroyed.
    @param parent the parent window in the front of which it should be displayed
-   @param destroy_with_parent relevant when the box has a parent (default is false)
    @param title the title of the dialog
    @param buttons the list of button labels.
    @param default the index of the default answer
@@ -58,7 +57,6 @@ val popup_menu : entries: menu_entry list -> button: int -> time: int32 -> unit
 *)
 val question_box :
     ?parent:#GWindow.window_skel ->
-    ?destroy_with_parent:bool ->
     title:string ->
     buttons:string list ->
     ?default:int -> ?icon:#GObj.widget -> string -> int
@@ -66,7 +64,6 @@ val question_box :
 (**This function is used to display a message in a dialog box with just an Ok button.
    We use [question_box] with just an ok button.
    @param parent the parent window in the front of which it should be displayed
-   @param destroy_with_parent relevant when the box has a parent (default is false)
    @param title the title of the dialog
    @param icon a widget (usually a pixmap) which can be displayed on the left
      of the window.
@@ -74,12 +71,13 @@ val question_box :
    @param message the text to display
 *)
 val message_box :
-    ?parent:#GWindow.window_skel -> ?destroy_with_parent:bool ->
+    ?parent:#GWindow.window_skel ->
     title:string -> ?icon:#GObj.widget -> ?ok:string -> string -> unit
 
 (** Make the user type in a string. 
    @return [None] if the user clicked on cancel, or [Some s] if the user
    clicked on the ok button.
+   @param parent the parent window in the front of which it should be displayed
    @param title the title of the dialog
    @param ok the text for the confirmation button (default is "Ok")
    @param cancel the text for the cancel button (default is "Cancel")
@@ -87,12 +85,14 @@ val message_box :
    @param message the text to display
 *)
 val input_string :
+    ?parent:#GWindow.window_skel ->
     title:string ->
     ?ok:string -> ?cancel:string -> ?text:string -> string -> string option
 
 (** Make the user type in a text.
    @return [None] if the user clicked on cancel, or [Some s] if the user
    clicked on the ok button.
+   @param parent the parent window in the front of which it should be displayed
    @param title the title of the dialog
    @param ok the text for the confirmation button (default is "Ok")
    @param cancel the text for the cancel button (default is "Cancel")
@@ -100,6 +100,7 @@ val input_string :
    @param message the text to display
 *)
 val input_text :
+    ?parent:#GWindow.window_skel ->
     title:string ->
       ?ok:string -> ?cancel:string -> ?text:string -> string -> string option
 
@@ -148,6 +149,7 @@ class ['a] tree_selection :
    if the user canceled the selection.
 *)
 val tree_selection_dialog :
+  ?parent:#GWindow.window_skel ->
   tree:'a tree ->
   label:('a -> string) ->
   info:('a -> string) ->


### PR DESCRIPTION
This extends PR #12 as proposed [here](https://github.com/garrigue/lablgtk/pull/12#issuecomment-439335466).

We simplify the API by making `destroy_with_parent` true by default whenever `parent` is given. We add option `parent` to `tree_selection_dialog`, `input_text` and `input_string`.