### PR TITLE
Remove properties allow-grow and allow-shrink from GtkWindow.

### DIFF
--- a/src/gAssistant.mli
+++ b/src/gAssistant.mli
@@ -93,8 +93,6 @@ end
 
 (** @gtkdoc gtk GtkPlug *)
 val assistant : ?title:string ->
-  ?allow_grow:bool ->
-  ?allow_shrink:bool ->
   ?decorated:bool ->
   ?deletable:bool ->
   ?focus_on_map:bool ->

--- a/src/gWindow.mli
+++ b/src/gWindow.mli
@@ -48,8 +48,6 @@ class window_skel : 'a obj ->
     method resize : width:int -> height:int -> unit
     method show : unit -> unit
     method set_accept_focus : bool -> unit
-    method set_allow_grow : bool -> unit
-    method set_allow_shrink : bool -> unit
     method set_decorated : bool -> unit
     method set_default_height : int -> unit
     method set_default_size : width:int -> height:int -> unit
@@ -81,8 +79,6 @@ class window_skel : 'a obj ->
     method set_type_hint : Gdk.Tags.window_type_hint -> unit
     method set_wmclass : name:string -> clas:string -> unit
     method accept_focus : bool
-    method allow_grow : bool
-    method allow_shrink : bool
     method decorated : bool
     method default_height : int
     method default_width : int
@@ -129,8 +125,6 @@ class window : ([> Gtk.window] as 'a) obj ->
 val window :
   ?kind:Tags.window_type ->
   ?title:string ->
-  ?allow_grow:bool ->
-  ?allow_shrink:bool ->
   ?decorated:bool ->
   ?deletable:bool ->
   ?focus_on_map:bool ->
@@ -212,8 +206,6 @@ val dialog :
   ?parent:#window_skel ->
   ?destroy_with_parent:bool ->
   ?title:string ->
-  ?allow_grow:bool ->
-  ?allow_shrink:bool ->
   ?decorated:bool ->
   ?deletable:bool ->
   ?focus_on_map:bool ->
@@ -277,8 +269,6 @@ val message_dialog :
   ?parent:#window_skel ->
   ?destroy_with_parent:bool ->
   ?title:string ->
-  ?allow_grow:bool ->
-  ?allow_shrink:bool ->
   ?decorated:bool ->
   ?deletable:bool ->
   ?focus_on_map:bool ->
@@ -372,8 +362,6 @@ val about_dialog :
   ?parent:#window_skel ->
   ?destroy_with_parent:bool ->
   ?title:string ->
-  ?allow_grow:bool ->
-  ?allow_shrink:bool ->
   ?decorated:bool ->
   ?deletable:bool ->
   ?focus_on_map:bool ->
@@ -427,8 +415,6 @@ val file_chooser_dialog :
   ?parent:#window_skel ->
   ?destroy_with_parent:bool ->
   ?title:string ->
-  ?allow_grow:bool ->
-  ?allow_shrink:bool ->
   ?decorated:bool ->
   ?deletable:bool ->
   ?focus_on_map:bool ->

--- a/src/gtkBase.props
+++ b/src/gtkBase.props
@@ -187,8 +187,6 @@ class Orientable wrap : Object {
 class Window set wrap : Bin {
   "title"                gchararray           : Read / Write
   "accept-focus"         gboolean             : Read / Write / NoSet
-  "allow-grow"           gboolean             : Read / Write
-  "allow-shrink"         gboolean             : Read / Write
   "decorated"            gboolean             : Read / Write
   "default-height"       gint                 : Read / Write / NoSet
   "default-width"        gint                 : Read / Write / NoSet


### PR DESCRIPTION
These properties were deprecated in GTK 2.22 and do not exist anymore
in GTK3. A lablgtk application that tries to use them will crash with
an obscure error message. This was the case for Why3.