### PR TITLE
Restore GtkMenu.MenuItem.separator_create.

### DIFF
--- a/src/gtkMenu.ml
+++ b/src/gtkMenu.ml
@@ -37,6 +37,8 @@ module MenuItem = struct
       = "ml_gtk_menu_item_new_with_label"
   external create_with_mnemonic : string -> menu_item obj
       = "ml_gtk_menu_item_new_with_mnemonic"
+  external separator_create : unit -> menu_item obj
+      = "ml_gtk_separator_menu_item_new"
   let create ?(use_mnemonic=false) ?label () =
     match label with None -> create []
     | Some label -> if use_mnemonic then 


### PR DESCRIPTION
There does not seem to be anything wrong with the function and it is
used by Why3.