### PR TITLE
Support property "expand" of GtkTreeViewColumn.

### DIFF
--- a/src/gTree.mli
+++ b/src/gTree.mli
@@ -305,6 +305,7 @@ class view_column : tree_view_column obj ->
     method alignment : float
     method clickable : bool
     method connect : view_column_signals
+    method expand : bool
     method fixed_width : int
     method get_sort_column_id : int
     method max_width : int
@@ -313,6 +314,7 @@ class view_column : tree_view_column obj ->
     method resizable : bool
     method set_alignment : float -> unit
     method set_clickable : bool -> unit
+    method set_expand : bool -> unit
     method set_fixed_width : int -> unit
     method set_max_width : int -> unit
     method set_min_width : int -> unit

--- a/src/gtkTree.props
+++ b/src/gtkTree.props
@@ -170,6 +170,7 @@ class CellLayout abstract : Object {
 class TreeViewColumn wrap : Object {
   "alignment"            gfloat               : Read / Write
   "clickable"            gboolean             : Read / Write
+  "expand"               gboolean             : Read / Write
   "fixed-width"          gint                 : Read / Write
   "max-width"            gint                 : Read / Write
   "min-width"            gint                 : Read / Write


### PR DESCRIPTION
By default, the last column of a tree view gets all the extra space. This
property makes it possible to give that space to some other columns.

It is available since GTK 2.4 and is still present in GTK 3.