### PR TITLE
Support property "placeholder-text" of GtkEntry.

### DIFF
--- a/src/gEdit.mli
+++ b/src/gEdit.mli
@@ -142,6 +142,8 @@ class entry_signals : [> Gtk.entry] obj ->
       callback:(bool -> unit) -> GtkSignal.id (** @Since GTK 2.16 *)
     method notify_secondary_icon_sensitive :
       callback:(bool -> unit) -> GtkSignal.id (** @Since GTK 2.16 *)
+    method notify_placeholder_text :
+      callback:(string -> unit) -> GtkSignal.id (** @Since GTK 3.2 *)
   end
 
 (** A single line text entry field
@@ -161,6 +163,7 @@ class entry : ([> Gtk.entry] as 'a) obj ->
     method set_has_frame : bool -> unit
     method set_invisible_char : int -> unit
     method set_max_length : int -> unit
+    method set_placeholder_text : string -> unit
     method set_text : string -> unit
     method set_visibility : bool -> unit
     method set_width_chars : int -> unit
@@ -170,6 +173,7 @@ class entry : ([> Gtk.entry] as 'a) obj ->
     method has_frame : bool
     method invisible_char : int
     method max_length : int
+    method placeholder_text : string
     method visibility : bool
     method width_chars : int
     method xalign : float
@@ -211,6 +215,7 @@ val entry :
   ?has_frame:bool ->
   ?width_chars:int ->
   ?xalign:float ->
+  ?placeholder_text:string ->
   ?width:int -> ?height:int ->
   ?packing:(widget -> unit) -> ?show:bool -> unit -> entry
 

--- a/src/gtkEdit.props
+++ b/src/gtkEdit.props
@@ -79,6 +79,8 @@ class Entry set wrap wrapsig : Editable {
   "secondary-icon-stock"       GtkStock       : Read / Write / NoSet / NoGet
   "secondary-icon-tooltip-markup" gchararray  : Read / Write / NoSet / NoGet
   "secondary-icon-tooltip-text" gchararray    : Read / Write / NoSet / NoGet
+  (* Since 3.2 *)
+  "placeholder-text"     gchararray           : Read / Write
   method get_completion : "Gtk.entry_completion option"
   method set_completion : "Gtk.entry_completion -> unit"
   signal activate


### PR DESCRIPTION
It is available since GTK 3.2.