### PR TITLE
Exporting destroy in misc signals

### DIFF
--- a/src/gObj.ml
+++ b/src/gObj.ml
@@ -216,6 +216,7 @@ end
 
 and misc_signals obj = object (self)
   inherit [_] gobject_signals obj
+  method destroy = self#connect Signals.destroy
   method show = self#connect Signals.show
   method hide = self#connect Signals.hide
   method map = self#connect Signals.map

--- a/src/gObj.mli
+++ b/src/gObj.mli
@@ -287,6 +287,7 @@ and widget : ([> Gtk.widget] as 'a) obj ->
 and misc_signals : Gtk.widget obj ->
   object ('b)
     inherit gtkobj_signals
+    method destroy : callback:(unit -> unit) -> GtkSignal.id
     method hide : callback:(unit -> unit) -> GtkSignal.id
     method map : callback:(unit -> unit) -> GtkSignal.id
     method parent_set : callback:(widget option -> unit) -> GtkSignal.id


### PR DESCRIPTION
Hi @garrigue, CoqIDE was also using one instance of `destroy` from `misc_signals` (formerly via `gtkobj_signals_impl`). I'm not very comfortable with the organization of signals but it seems that this signal is now directly provided as a `Widget` signal and could be exported. This is what this PR is doing for lablgtk3.