### PR TITLE
[build] Add support for building and releasing with Dune.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ autom4te.cache
 test_dynlink.*
 *~
 *.sw[po]
+
+# Dune stuff
+_build
+.merlin
+*.install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+dist: xenial
+sudo: required
+language: c
+cache:
+  apt: true
+  directories:
+  - $HOME/.opam
+addons:
+  apt:
+    packages:
+    - libgtksourceview-3.0-dev
+env:
+  global:
+  - OPAMJOBS="2"
+  - OPAMROOTISOK="true"
+  - OPAMYES="true"
+  - COMPILER="4.06.1"
+  - BASE_OPAM="dune cairo2"
+
+  # Main test suite, some examples don't work in 4.05.0
+  matrix:
+  - TEST_TARGET="build"       COMPILER="4.05.0"
+  - TEST_TARGET="build-all"   COMPILER="4.06.1"
+  - TEST_TARGET="build-all"   COMPILER="4.07.1"
+  - TEST_TARGET="opam"        COMPILER="4.07.1"
+
+install:
+- sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.1/opam-2.0.1-x86_64-linux -o /usr/bin/opam
+- sudo chmod 755 /usr/bin/opam
+- opam init -c "$COMPILER" --disable-sandboxing
+- opam switch set "$COMPILER"
+- eval $(opam env)
+- opam install $BASE_OPAM
+- opam list
+
+script:
+- set -e
+- echo 'Building LablGtk...' && echo -en 'travis_fold:start:lablgtk.build\\r'
+- make -f Makefile.travis "$TEST_TARGET"
+- ls -l
+- echo -en 'travis_fold:end:lablgtk.build\\r'

--- a/CHANGES
+++ b/CHANGES
@@ -58,6 +58,9 @@ In Lablgtk-3.0.beta2:
   * add memory management for cairo_t
   * update support for GtkSpell
 
+2018.11.26 [Emilio J. Gallego Arias]
+  * add support for building with Dune
+
 2018.11.20 [Hugo Herbelin]
   * restore deprecated by still alive widgets and methods
   * various fixes to make gtksourceview3 work with CoqIDE

--- a/Makefile.travis
+++ b/Makefile.travis
@@ -1,0 +1,14 @@
+.PHONY: build build-all opam
+
+build:
+	dune build
+
+build-all:
+	dune build @all
+
+# We first pin lablgtk3 as to avoid problems with parallel make
+opam:
+	opam pin add lablgtk3 . --kind=path -y
+	opam install lablgtk3
+	opam pin add lablgtk3-sourceview3 . --kind=path -y
+	opam install lablgtk3-sourceview3

--- a/README.dune.md
+++ b/README.dune.md
@@ -1,0 +1,72 @@
+This file describes the Dune setup for lablgtk and the release
+instructions.
+
+## Dune setup
+
+Dune takes care of all the C-stub needed to compile lablgtk almost
+automatically. The `src/dune` file is mostly self-describing.
+
+### Packaging choices and C library version detection
+
+The main choice we had to do is how to structure the OPAM packages. In
+lablgtk2, there was a single package, however it would build different
+binaries based on what it could detect. This was a bit fragile due to
+lack of reproducible, thus in lablgtk3 each C library has its own OPAM
+package.
+
+We still depend on the `conf-packages`, but note however that the
+build system does it own versioned C library check.
+
+The discussion at the caml-list
+https://sympa.inria.fr/sympa/arc/caml-list/2018-12/msg00017.html
+provides some more insight on this choice.
+
+The `dune_config` tool is a simple wrapper that can be used to query
+`pkg-config` for flags and version checks.
+
+### Auto-generation of files
+
+The lablgtk3 build uses the `varcc` and `propcc` scripts to
+auto-generate some files. The rules for such files are in
+`dune-enum.sexp` and `dune-prop.sexp`. These files could be also
+auto-generated in the future using Dune's promote mechanism.
+
+## How to release a new version of lablgtk to OPAM
+
+**Quick release instructions:** Run `git tag -a` + `dune-release`.
+
+The preferred workflow to release a new set of OPAM packages is to use
+`dune-release`.
+
+The first (and most important) step is to tag the release and push it
+to the main repository.
+
+We recommend you do this manually. As `dune-release` uses `git
+describe` to gather versioning information, your tag must be
+annotated. Using `git tag -a` or `git tag -s` will do the job. Please
+add the version changes to the tag annotation message.
+
+You can also use `dune-release tag`, which will try to infer the
+tag information from `CHANGES.md`, however the current heuristics
+seem too fragile and the changes list may not be properly updated.
+
+Once the tag is in place, calling `dune-release` will build, lint, run
+the tests, create the opam package, upload the archives and
+docs to the release page, and submit a pull request to the OPAM
+repository.
+
+Under the hood, `dune-release` executes the following 4 commands:
+
+```
+dune-release distrib       # Create the distribution archive
+dune-release publish       # Publish it on the WWW with its documentation
+dune-release opam pkg      # Create an opam package
+dune-release opam submit   # Submit it to OCaml's opam repository
+```
+
+It is often useful to run the commands separately as to have better
+control of the release process.
+
+Note that you will need the proper permissions for the `publish` step,
+including setting a Github access token, see `dune-release help
+files` for more information.

--- a/applications/browser/dune
+++ b/applications/browser/dune
@@ -1,0 +1,5 @@
+; (executable
+;  (name editor)
+; (public_name browser)
+; (flags :standard -w -6-10-27 -no-strict-sequence)
+; (libraries str compiler-libs.common lablgtk3))

--- a/applications/camlirc/dune
+++ b/applications/camlirc/dune
@@ -1,0 +1,7 @@
+; (executable
+;  (name newmain)
+;  (flags :standard -w -3-9-10-26-27-33 -no-strict-sequence)
+;  (modules_without_implementation i_channel)
+;  (libraries str lablgtk3))
+
+; (ocamllex xml_lexer)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,45 @@
+# NB: image names can be found at
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted
+
+variables:
+  NJOBS: "2"
+  OPAMYES: "true"
+  BASE_OPAM: "dune cairo2"
+
+jobs:
+- job: macOS
+  pool:
+    vmImage: 'macOS-10.13'
+
+  steps:
+  - checkout: self
+    fetchDepth: 10
+
+  - script: |
+      set -e
+      brew update
+      brew install gnu-time opam pkg-config gtk+3 gtksourceview3
+
+      opam init -a -j "$NJOBS" --compiler=$COMPILER
+      opam switch set $COMPILER
+      eval $(opam env)
+      opam update
+      opam install -j "$NJOBS" $BASE_OPAM
+      opam list
+    displayName: 'Install dependencies'
+    env:
+      COMPILER: "4.07.1"
+
+  - script: |
+      set -e
+
+      eval $(opam env)
+      export LABLGTK_EXTRA_FLAGS="-DHAS_GTKQUARTZ"
+      dune build
+    displayName: 'Build lablgtk3 [base]'
+
+  - script: |
+      eval $(opam env)
+      export LABLGTK_EXTRA_FLAGS="-DHAS_GTKQUARTZ"
+      dune build @all
+    displayName: 'Build lablgtk3 [all]'

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.4)
+(name lablgtk3)

--- a/examples/dune
+++ b/examples/dune
@@ -1,0 +1,53 @@
+; copy test.xpm
+
+(executables
+ (names
+   about ; accel_tree
+   action ; assistant
+   assistant_tutorial
+   ; buttons
+   calc calendar cgets ; clist
+   combobox ; combo counter dcalendar
+   dialog-thread drawing ; druid
+   editor2 ; editor
+   entry2 entrycompletion ; entry
+   eventbox events2 events expander
+   fifteen filechooser ; fixed_editor
+   ; fixpoint
+   gioredirect giotest hello iconview ; image kaimono
+   ; label link_button lissajous
+   nihongo notebook
+   ; pixview pousse
+   progressbar radiobuttons ; rpn
+   ; runthread
+   scrolledwin ; seppala signal_override slide_show
+   socket spin
+   ; testdnd testgtk
+   testthread ; timer toolbar
+   tooltip tree tree_model tree_store ; tron
+ )
+ (modules
+   about accel_tree action assistant assistant_tutorial
+   buttons calc calendar cgets clist combobox combo counter
+   dcalendar dialog-thread drawing druid
+   editor2 editor
+   entry2 entrycompletion entry eventbox events2 events expander
+   fifteen filechooser fixed_editor fixpoint
+   gioredirect giotest hello iconview image kaimono
+   label link_button lissajous
+   nihongo notebook
+   pixview pousse progressbar radiobuttons rpn
+   runthread
+   scrolledwin seppala signal_override slide_show socket spin
+   testdnd ; testgtk
+   testthread timer toolbar tooltip tree tree_model tree_store tron
+ )
+ (flags :standard -w -3-6-7-10-24-26-27-33-35 -no-strict-sequence)
+ (libraries lablgtk3))
+
+; Missing gtkspell in lablgtk3
+; (executables
+;  (names spell)
+;  (modules spell)
+;  (flags :standard -w -6)
+;  (libraries lablgtk2.gspell))

--- a/examples/image.ml
+++ b/examples/image.ml
@@ -20,6 +20,7 @@ let load_image file =
   close_in ic;
   buf
 
+(* This doesn't work in OCaml 4.05 *)
 let (.![]) = Bytes.get
 
 let rgb_at buf x y =

--- a/lablgtk3-sourceview3.opam
+++ b/lablgtk3-sourceview3.opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+
+description: "OCaml interface to GTK+, gtksourceview2 library"
+synopsis: "OCaml interface to GTK+"
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "http://lablgtk.forge.ocamlcore.org/"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+doc: "https://garrige.github.io/lablgtk/lablgtk-sourceview"
+license: "LGPL with linking exception"
+
+depends: [
+  "ocaml"                {         >= "4.05.0"  }
+  "dune"                 { build & >= "1.4.0"   }
+  "lablgtk3"             {            "0.beta3" }
+  "conf-gtksourceview3"  { build & >= "0"       }
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]

--- a/lablgtk3.opam
+++ b/lablgtk3.opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+
+description: "OCaml interface to GTK+"
+synopsis: "OCaml interface to GTK+"
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "http://lablgtk.forge.ocamlcore.org/"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+license: "LGPL with linking exception"
+doc: "https://garrige.github.io/lablgtk/lablgtk"
+
+depends: [
+  "ocaml"     {         >= "4.05.0" }
+  "dune"      { build & >= "1.4.0"  }
+  "conf-gtk3" { build & >= "18"     }
+  "cairo2"    {         >= "0.6"    }
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]

--- a/src/dune
+++ b/src/dune
@@ -1,0 +1,118 @@
+; Dune build file for lablgtk2
+; Written by EJGA, (c) 2018 MINES ParisTech
+; This file is in the public domain
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Common setup and tools                                               ;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(executable
+ (name dune_config)
+ (modules dune_config)
+ (libraries dune.configurator))
+
+(executable
+ (name varcc)
+ (modules varcc)
+ (flags :standard -w -3-6))
+
+(executable
+ (name propcc)
+ (modules propcc)
+ (flags :standard -w -3-6-27-35))
+
+; Maybe auto-generate?
+(include dune-enum.sexp)
+(include dune-prop.sexp)
+
+(rule
+ (targets cflag-extraflags.sexp)
+ (action (with-outputs-to cflag-extraflags.sexp (echo "(%{env:LABLGTK_EXTRA_FLAGS=})"))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Base lablgtk3                                                        ;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(rule
+ (targets
+   cflag-gtk+-3.0.sexp
+   clink-gtk+-3.0.sexp)
+ (action (run ./dune_config.exe -pkg gtk+-3.0 -version 3.18)))
+
+(library
+ (name lablgtk3)
+ (public_name lablgtk3)
+ (flags :standard -w -6-7-9-10-27-32-33-34-35-36-50 -no-strict-sequence)
+ (wrapped false)
+ (modules
+   ; gtkBrokenProps ogtkBrokenProps gtkBroken gBroken
+   gToolbox
+   gpointer gobject gutf8 gaux glib
+   gdkPixbuf pangoEnums pango
+   gdkEnums gdk gdkEvent gdkKeysyms
+   gtkEnums gtk gtkObject gtkSignal
+   gtkStock
+   gPango gDraw
+   gObj gUtil
+   gtkMain gMain
+   gtkThread
+   gtkWindow gWindow
+   gtkData gData
+   gContainer
+
+   gtkContainersProps ogtkContainersProps gtkContainers
+   gtkActionProps     ogtkActionProps                 gAction
+   gtkAssistantProps  ogtkAssistantProps  gtkAssistant gAssistant
+   gtkBaseProps       ogtkBaseProps       gtkBase
+   gtkBinProps        ogtkBinProps        gtkBin       gBin
+   gtkButtonProps     ogtkButtonProps     gtkButton    gButton
+   gtkEditProps       ogtkEditProps       gtkEdit      gEdit
+   gtkFileProps       ogtkFileProps       gtkFile      gFile
+   ; gtkListProps      ogtkListProps      gtkList      gList
+   gtkMenuProps       ogtkMenuProps       gtkMenu      gMenu
+   gtkMiscProps       ogtkMiscProps       gtkMisc      gMisc
+   gtkPackProps       ogtkPackProps       gtkPack      gPack
+   gtkRangeProps      ogtkRangeProps      gtkRange     gRange
+   gtkTextProps       ogtkTextProps       gtkText      gText
+   gtkTreeProps       ogtkTreeProps       gtkTree      gTree
+
+ )
+ (c_names
+   wrappers
+   ml_glib ml_gvaluecaml ml_gpointer ml_gobject
+   ml_pango
+   ml_gdk ml_gdkpixbuf
+   ml_gtk ml_gtkmisc
+
+   ml_gtkaction ml_gtkbin ml_gtkbutton ml_gtktext ml_gtkedit
+   ml_gtkmenu ml_gtkfile ml_gtktree ml_gtkpack
+   ; ml_gtkbroken ml_gtklist
+   ml_gtkstock ml_gtkrange ml_gtkassistant
+ )
+ ; Note we disable -Wdeprecated-declarations, but that should eventually be fixed.
+ (c_flags         (:include cflag-gtk+-3.0.sexp) (:include cflag-extraflags.sexp) -Wno-deprecated-declarations)
+ (c_library_flags (:include clink-gtk+-3.0.sexp))
+ (libraries threads cairo2))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; lablgtk3-sourceview3                                                 ;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule
+ (targets
+   cflag-gtksourceview-3.0.sexp
+   clink-gtksourceview-3.0.sexp)
+ (action (run ./dune_config.exe -pkg gtksourceview-3.0 -version 3.18)))
+
+(library
+ (name lablgtk3_sourceview3)
+ (public_name lablgtk3-sourceview3)
+ (flags :standard -w -6-7-27-32-33-34-36)
+ (wrapped false)
+ (modules_without_implementation
+   gtkSourceView3_types)
+ (modules
+   sourceView3Enums gtkSourceView3_types gtkSourceView3Props
+   ogtkSourceView3Props gtkSourceView3 gSourceView3)
+ (c_names ml_gtksourceview3)
+ (c_flags         (:include cflag-gtksourceview-3.0.sexp) (:include cflag-extraflags.sexp) -Wno-deprecated-declarations)
+ (c_library_flags (:include clink-gtksourceview-3.0.sexp))
+ (libraries lablgtk3))

--- a/src/dune-enum.sexp
+++ b/src/dune-enum.sexp
@@ -1,0 +1,36 @@
+; Enums
+(rule
+ (targets glib_tags.h glib_tags.c)
+ (action (run ./varcc.exe %{dep:glib_tags.var})))
+
+(rule
+ (targets gdk_tags.h gdk_tags.c gdkEnums.ml)
+ (action (run ./varcc.exe %{dep:gdk_tags.var})))
+
+(rule
+ (targets gdkpixbuf_tags.h gdkpixbuf_tags.c)
+ (action (run ./varcc.exe %{dep:gdkpixbuf_tags.var})))
+
+(rule
+ (targets gobject_tags.h gobject_tags.c)
+ (action (run ./varcc.exe %{dep:gobject_tags.var})))
+
+(rule
+ (targets gtk_tags.h gtk_tags.c gtkEnums.ml)
+ (action (run ./varcc.exe %{dep:gtk_tags.var})))
+
+(rule
+ (targets pango_tags.h pango_tags.c pangoEnums.ml)
+ (action (run ./varcc.exe %{dep:pango_tags.var})))
+
+(rule
+ (targets sourceView3_tags.h sourceView3_tags.c sourceView3Enums.ml)
+ (action (run ./varcc.exe %{dep:sourceView3_tags.var})))
+
+(rule
+ (targets gtkgl_tags.h gtkgl_tags.c)
+ (action (run ./varcc.exe %{dep:gtkgl_tags.var})))
+
+(rule
+ (targets gnomeui_tags.h gnomeui_tags.c)
+ (action (run ./varcc.exe %{dep:gnomeui_tags.var})))

--- a/src/dune-prop.sexp
+++ b/src/dune-prop.sexp
@@ -1,0 +1,74 @@
+; Props
+(rule
+ (targets gtkContainersProps.ml ogtkContainersProps.ml)
+ (action (run ./propcc.exe %{dep:gtkContainers.props})))
+
+(rule
+ (targets gtkActionProps.ml ogtkActionProps.ml)
+ (action (run ./propcc.exe %{dep:gtkAction.props})))
+
+(rule
+ (targets gtkAssistantProps.ml ogtkAssistantProps.ml)
+ (action (run ./propcc.exe %{dep:gtkAssistant.props})))
+
+(rule
+ (targets gtkBaseProps.ml ogtkBaseProps.ml)
+ (action (run ./propcc.exe %{dep:gtkBase.props})))
+
+(rule
+ (targets gtkBinProps.ml ogtkBinProps.ml)
+ (action (run ./propcc.exe %{dep:gtkBin.props})))
+
+; (rule
+;  (targets gtkBrokenProps.ml ogtkBrokenProps.ml)
+;  (action (run ./propcc.exe %{dep:gtkBroken.props})))
+
+(rule
+ (targets gtkButtonProps.ml ogtkButtonProps.ml)
+ (action (run ./propcc.exe %{dep:gtkButton.props})))
+
+(rule
+ (targets gtkEditProps.ml ogtkEditProps.ml)
+ (action (run ./propcc.exe %{dep:gtkEdit.props})))
+
+(rule
+ (targets gtkFileProps.ml ogtkFileProps.ml)
+ (action (run ./propcc.exe %{dep:gtkFile.props})))
+
+; (rule
+;  (targets gtkListProps.ml ogtkListProps.ml)
+;  (action (run ./propcc.exe %{dep:gtkList.props})))
+
+(rule
+ (targets gtkMenuProps.ml ogtkMenuProps.ml)
+ (action (run ./propcc.exe %{dep:gtkMenu.props})))
+
+(rule
+ (targets gtkMiscProps.ml ogtkMiscProps.ml)
+ (action (run ./propcc.exe %{dep:gtkMisc.props})))
+
+(rule
+ (targets gtkPackProps.ml ogtkPackProps.ml)
+ (action (run ./propcc.exe %{dep:gtkPack.props})))
+
+(rule
+ (targets gtkSourceView3Props.ml ogtkSourceView3Props.ml)
+ (action (run ./propcc.exe %{dep:gtkSourceView3.props})))
+
+(rule
+ (targets gtkRangeProps.ml ogtkRangeProps.ml)
+ (action (run ./propcc.exe %{dep:gtkRange.props})))
+
+(rule
+ (targets gtkTextProps.ml ogtkTextProps.ml)
+ (action (run ./propcc.exe %{dep:gtkText.props})))
+
+(rule
+ (targets gtkTreeProps.ml ogtkTreeProps.ml)
+ (action (run ./propcc.exe %{dep:gtkTree.props})))
+
+; Gives a parsing error in gnomeCanvasProps.props
+;
+; (rule
+;  (targets gnomeCanvasProps.ml ognomeCanvasProps.ml)
+;  (action (run ./propcc.exe %{dep:gnomeCanvas.props})))

--- a/src/dune_config.ml
+++ b/src/dune_config.ml
@@ -1,0 +1,39 @@
+module C = Configurator.V1
+
+(* XXX: Use `die` *)
+let error str =
+  Format.eprintf "configure error: %s.@\n%!" str;
+  exit 1
+
+module Option = struct
+  let require ~message = function
+    | None   -> error message
+    | Some v -> v
+
+  let cata f d = function
+    | None -> d
+    | Some x -> f x
+end
+
+let query_pkg p ~package =
+  Option.require ~message:(package ^ " not found") C.Pkg_config.(query p ~package)
+
+let gen_pkg p ~package ~version =
+  let file kind = kind ^ "-" ^ package ^ ".sexp" in
+  let package =
+    Option.cata (fun version -> Format.sprintf "%s >= %s" package version) package version in
+  let c_g = query_pkg p ~package in
+  C.Flags.write_sexp (file "cflag") c_g.C.Pkg_config.cflags;
+  C.Flags.write_sexp (file "clink") c_g.C.Pkg_config.libs
+
+let pkg = ref ""
+let version = ref None
+
+let main t =
+  let p = Option.require ~message:"pkg_config not installed" C.Pkg_config.(get t) in
+  gen_pkg p ~package:!pkg ~version:!version
+
+let _ =
+  let args = [ "-pkg", Arg.String (fun s -> pkg := s), "package"
+             ; "-version", Arg.String (fun v -> version := Some v), "version" ] in
+  C.main ~args ~name:"lablgtk3" main

--- a/src/introspection/Gtk-3.0.gir
+++ b/src/introspection/Gtk-3.0.gir
@@ -1,1 +1,0 @@
-/usr/share/gir-1.0/Gtk-3.0.gir


### PR DESCRIPTION
We add preliminary support for building with Dune to lablgtk3; it
seems to work well and does provide some advantages:

- compositional build with other developments, for example CoqIDE,
- it allows for an easier layout / library reorganization if wished,
- automatic management of install targets, opam install file, META, stubs,
- automatic generation of documentation with `odoc`.

Release / usage instructions are placed in `README.dune.md`.

The dune files use an "explicit" style. While a bit more
verbose than other setup, it is very easy to understand.

Note we pass `-Wno-deprecated-declarations` to the C compiler as to
avoid a super-verbose build. We also disable a few OCaml warnings.

One strong motivation to do this PR is to help the GTK 3 porting
effort and this provides a seamless developer experience.

Following discussion on caml-list, we provide one opam package for
each C library. This is IMO more consistent with what packaging
systems do and allows for better dependencies in the OPAM world. For
example, Coq can depend now on `lablgtk3-sourceview3`.

We still depend on the `conf-packages` as to get depext information,
but it is not necessary as the dune-based config script also does C
version checks.

Things that would be worth to do in future PRs are:

- linting: the large amount of OCaml and C warnings should be addressed
- OSX and Win32 support, Travis CI for these platforms
- make all examples work again
- cleanup makefiles, remove old make system. To be done after we add
  OSX/Win32 testing
- generate `varcc` / `propcc` rules using promote

This is based on #14