### PR TITLE
[examples] Fix a few examples.

### DIFF
--- a/Makefile.travis
+++ b/Makefile.travis
@@ -3,6 +3,7 @@
 build:
 	dune build
 
+# This also builds examples
 build-all:
 	dune build @all
 

--- a/examples/dune
+++ b/examples/dune
@@ -12,8 +12,7 @@
    editor2 ; editor
    entry2 entrycompletion ; entry
    eventbox events2 events expander
-   fifteen filechooser ; fixed_editor
-   ; fixpoint
+   fifteen filechooser ; fixed_editor fixpoint
    gioredirect giotest hello iconview ; image kaimono
    ; label link_button lissajous
    nihongo notebook

--- a/examples/fixed_editor.ml
+++ b/examples/fixed_editor.ml
@@ -274,6 +274,7 @@ let window1 () =
 
     
 let main () =
+  let _ = Main.init () in
   window1 ();
   dnd_source_window ();
   Main.main ()

--- a/examples/fixpoint.ml
+++ b/examples/fixpoint.ml
@@ -18,6 +18,7 @@ let rec fix ~f ~eq x =
 let eq_float x y = abs_float (x -. y) < 1e-13
 
 let _ =
+  let _ = Main.init () in
   let top = GWindow.window () in
   top#connect#destroy ~callback:Main.quit;
   let vbox = GPack.vbox ~packing: top#add () in


### PR DESCRIPTION
This is ported from the GTK2 branch, so it is not enough for GTK3.

Note the additions of the `-linkall` flag. As far as I can see this is
necessary in order to avoid:

```
Fatal error: exception Failure("Gobject.unsafe_create : type GtkFrame is not yet defined")
```

etc...