### PR TITLE
[build] Teach dune about generation from ml4 files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   - OPAMROOTISOK="true"
   - OPAMYES="true"
   - COMPILER="4.07.1"
-  - BASE_OPAM="dune cairo2"
+  - BASE_OPAM="camlp4 dune cairo2"
 
   # Main test suite, some examples don't work in 4.05.0
   matrix:

--- a/src/dune
+++ b/src/dune
@@ -10,15 +10,23 @@
  (modules dune_config)
  (libraries dune.configurator))
 
-(executable
- (name varcc)
- (modules varcc)
- (flags :standard -w -3-6))
+; We use a bash rule to ensure we call the byte version and thus we
+; avoid the auto-printer selection in Camlp4AutoPrinter.
+(rule
+ (targets varcc.ml)
+ (deps (:source varcc.ml4))
+ (mode promote)
+ (action (bash "camlp4o pr_o.cmo -impl %{source} -o %{targets}")))
 
-(executable
- (name propcc)
- (modules propcc)
- (flags :standard -w -3-6-27-35))
+(rule
+ (targets propcc.ml)
+ (deps (:source propcc.ml4))
+ (mode promote)
+ (action (bash "camlp4o pr_o.cmo -impl %{source} -o %{targets}")))
+
+(executables
+ (names varcc propcc)
+ (modules varcc propcc))
 
 ; Maybe auto-generate?
 (include dune-enum.sexp)

--- a/src/varcc.ml
+++ b/src/varcc.ml
@@ -22,7 +22,7 @@ let camlize id =
        if (id.[i] >= 'A') && (id.[i] <= 'Z')
        then
          (if i > 0 then Buffer.add_char b '_' else ();
-          Buffer.add_char b (Char.lowercase id.[i]))
+          Buffer.add_char b (Char.lowercase_ascii id.[i]))
        else Buffer.add_char b id.[i]
      done;
      Buffer.contents b)
@@ -178,7 +178,7 @@ let declaration ~hc ~cc (__strm : _ Stream.t) =
                                                         oh
                                                           "#define MLTAG_%s\t((value)(%d*2+1))\n"
                                                           tag hash));
-                                          if List.mem "noconv" flags
+                                          if List.mem "noconv" ~set: flags
                                           then ()
                                           else (* compute C name *)
                                             (let ctag tag trans =
@@ -218,19 +218,20 @@ let declaration ~hc ~cc (__strm : _ Stream.t) =
                                                     | (Some '#', prefix) ->
                                                         prefix ^
                                                           ((String.
-                                                              uncapitalize
+                                                              uncapitalize_ascii
                                                               tag)
                                                              ^ suffix)
                                                     | (Some '^', prefix) ->
                                                         prefix ^
-                                                          ((String.uppercase
+                                                          ((String.
+                                                              uppercase_ascii
                                                               tag)
                                                              ^ suffix)
                                                     | _ ->
                                                         prefix ^
                                                           (tag ^ suffix))
                                              and cname =
-                                               String.capitalize name
+                                               String.capitalize_ascii name
                                              in
                                                (all_convs :=
                                                   (name, mlname, tags, flags) ::
@@ -254,10 +255,10 @@ let declaration ~hc ~cc (__strm : _ Stream.t) =
                                                           (not
                                                              (List.mem
                                                                 "public"
-                                                                flags)))
+                                                                ~set: flags)))
                                                          ||
                                                          (List.mem "private"
-                                                            flags)
+                                                            ~set: flags)
                                                      then "static "
                                                      else ""
                                                    in
@@ -382,7 +383,7 @@ let process ic ~hc ~cc =
                              ~f:
                                (fun (_, s, _, flags) ->
                                   let conv =
-                                    if List.mem "flags" flags
+                                    if List.mem "flags" ~set: flags
                                     then "Gobject.Data.flags"
                                     else enum
                                   in out "@ let %s = %s %s_tbl" s conv s);

--- a/src/varcc.ml4
+++ b/src/varcc.ml4
@@ -22,7 +22,7 @@ let camlize id =
   for i = 0 to String.length id - 1 do
     if id.[i] >= 'A' && id.[i] <= 'Z' then begin
       if i > 0 then Buffer.add_char b '_';
-      Buffer.add_char b (Char.lowercase id.[i])
+      Buffer.add_char b (Char.lowercase_ascii id.[i])
     end
     else Buffer.add_char b id.[i]
   done;
@@ -94,7 +94,7 @@ let declaration ~hc ~cc = parser
           end;
 	  oh "#define MLTAG_%s\t((value)(%d*2+1))\n" tag hash;
       end;
-    if List.mem "noconv" flags then () else
+    if List.mem "noconv" ~set:flags then () else
     (* compute C name *)
     let ctag tag trans =
       if trans <> "" then trans else
@@ -110,13 +110,13 @@ let declaration ~hc ~cc = parser
 	  String.sub prefix ~pos:0 ~len:(String.length prefix - 1)
       with
 	Some '#', prefix ->
-	  prefix ^ String.uncapitalize tag ^ suffix
+	  prefix ^ String.uncapitalize_ascii tag ^ suffix
       |	Some '^', prefix ->
-	  prefix ^ String.uppercase tag ^ suffix
+	  prefix ^ String.uppercase_ascii tag ^ suffix
       |	_ ->
 	  prefix ^ tag ^ suffix
     and cname =
-      String.capitalize name
+      String.capitalize_ascii name
     in
     all_convs := (name, mlname, tags, flags) :: !all_convs;
     let tags =
@@ -127,7 +127,7 @@ let declaration ~hc ~cc = parser
     (* Output table to code file *)
     oc "/* %s : conversion table */\n" name;
     let static =
-      if !static && not (List.mem "public" flags) || List.mem "private" flags
+      if !static && not (List.mem "public" ~set:flags) || List.mem "private" ~set:flags
       then "static " else "" in
     oc "%sconst lookup_info ml_table_%s[] = {\n" static name;
     may guard
@@ -206,7 +206,7 @@ let process ic ~hc ~cc =
       List.iter convs ~f:
         begin fun (_,s,_,flags) ->
           let conv =
-            if List.mem "flags" flags then "Gobject.Data.flags" else enum in
+            if List.mem "flags" ~set:flags then "Gobject.Data.flags" else enum in
           out "@ let %s = %s %s_tbl" s conv s
         end;
       out "@]@.end@.";


### PR DESCRIPTION
We do a warnings cleanup on the way.

The camlp4 rule has to be a bit special to ensure the loading of
`pr_o` as for promotion to work better; by default, `camlp4o` will use
Camlp4AutoPrinter which does:

```ocaml
if Unix.isatty Unix.stdout then
  enable_ocaml_printer ()
else
  enable_dump_ocaml_ast_printer ();
```

which turns out to be very inconvenient.
