### PR TITLE
[build] Remove failed flag workaround.

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -60,7 +60,7 @@
 (library
  (name lablgtk3)
  (public_name lablgtk3)
- (flags :standard -w -6-7-9-10-27-32-33-34-35-36-50 -no-strict-sequence -alias-deps)
+ (flags :standard -w -6-7-9-10-27-32-33-34-35-36-50 -no-strict-sequence)
  (wrapped false)
  (modules
    ; gtkBrokenProps ogtkBrokenProps gtkBroken gBroken


### PR DESCRIPTION
This seems to be a noop and it is not needed anymore after
d086ec7576758f136be21397ee61a793825f666b