### PR TITLE
[build] Conflict with Dune 1.7.0

### DIFF
--- a/lablgtk3.opam
+++ b/lablgtk3.opam
@@ -13,7 +13,8 @@ doc: "https://garrigue.github.io/lablgtk/lablgtk"
 
 depends: [
   "ocaml"     {         >= "4.05.0" }
-  "dune"      { build & >= "1.4.0"  }
+  "dune"      { build & >= "1.4.0"
+                      & != "1.7.0"  } # Due to dune/dune#1833
   "conf-gtk3" { build & >= "18"     }
   "cairo2"    {         >= "0.6"    }
 ]


### PR DESCRIPTION
Bug https://github.com/ocaml/dune/pull/1833 makes our quoting strategy
fail; unfortunately it is not easy to fix due to OS-specific issues.

IMHO the issue is not so serious as to warrant an ugly workaround,
thus we rather declare a conflict with Dune 1.7.0.
