### PR TITLE
fix compilation with OCaml 4.08

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 # Makefile for lablgtk.
 
-COMPILER = $(CAMLC) $(MLFLAGS) $(MLBYTEFLAGS) -w s-3+52 -warn-error A-52 -c
+COMPILER = $(CAMLC) $(MLFLAGS) $(MLBYTEFLAGS) -w s-3+52 -warn-error A-52-61 -c
 LINKER = $(CAMLC) $(MLFLAGS) $(MLBYTEFLAGS)
 COMPOPT = $(CAMLOPT) $(MLFLAGS) -w s -c
 LINKOPT = $(CAMLOPT) $(MLFLAGS)


### PR DESCRIPTION
OCaml 4.08 introduces warning 61 about unannotated boxing status, which becomes
an error due to lablgtk's compilation flags. The simplest patch consists in
not considering it as an error.

(This is a quick fix to enable lablgtk-dependent packages to compile in 4.08 for beta testing, but adding the required annotations would be a better solution.)