### PR TITLE
Add additional Pango.Layout functions

### DIFF
--- a/src/ml_pango.c
+++ b/src/ml_pango.c
@@ -197,6 +197,8 @@ ML_1 (pango_layout_get_baseline, PangoLayout_val, Val_int)
 ML_1 (pango_layout_get_line_count, PangoLayout_val, Val_int)
 ML_1 (pango_layout_is_wrapped, PangoLayout_val, Val_bool)
 ML_1 (pango_layout_is_ellipsized, PangoLayout_val, Val_bool)
+ML_1 (pango_layout_get_alignment, PangoLayout_val, Val_pango_alignment)
+ML_2 (pango_layout_set_alignment, PangoLayout_val, Pango_alignment_val, Unit)
 CAMLprim value ml_pango_layout_get_size(value layout)
 {
   int width, height;

--- a/src/ml_pango.c
+++ b/src/ml_pango.c
@@ -193,6 +193,8 @@ ML_1 (pango_layout_get_justify, PangoLayout_val, Val_bool)
 ML_2 (pango_layout_set_single_paragraph_mode, PangoLayout_val, Bool_val, Unit)
 ML_1 (pango_layout_get_single_paragraph_mode, PangoLayout_val, Val_bool)
 ML_1 (pango_layout_context_changed, PangoLayout_val, Unit)
+ML_1 (pango_layout_get_baseline, PangoLayout_val, Val_int)
+ML_1 (pango_layout_get_line_count, PangoLayout_val, Val_int)
 CAMLprim value ml_pango_layout_get_size(value layout)
 {
   int width, height;

--- a/src/ml_pango.c
+++ b/src/ml_pango.c
@@ -195,6 +195,8 @@ ML_1 (pango_layout_get_single_paragraph_mode, PangoLayout_val, Val_bool)
 ML_1 (pango_layout_context_changed, PangoLayout_val, Unit)
 ML_1 (pango_layout_get_baseline, PangoLayout_val, Val_int)
 ML_1 (pango_layout_get_line_count, PangoLayout_val, Val_int)
+ML_1 (pango_layout_is_wrapped, PangoLayout_val, Val_bool)
+ML_1 (pango_layout_is_ellipsized, PangoLayout_val, Val_bool)
 CAMLprim value ml_pango_layout_get_size(value layout)
 {
   int width, height;

--- a/src/pango.ml
+++ b/src/pango.ml
@@ -67,6 +67,8 @@ module Tags = struct
 
   type ellipsize_mode = [ `NONE | `START | `MIDDLE | `END ]
 
+  type alignment = [ `LEFT | `CENTER | `RIGHT ]
+
   open Gpointer
   external _get_tables : unit ->
       style variant_table
@@ -222,4 +224,8 @@ module Layout = struct
   external get_line_count : layout -> int = "ml_pango_layout_get_line_count"
   external is_wrapped : layout -> bool = "ml_pango_layout_is_wrapped"
   external is_ellipsized : layout -> bool = "ml_pango_layout_is_ellipsized"
+  external get_alignment : layout -> alignment
+    = "ml_pango_layout_get_alignment"
+  external set_alignment : layout -> alignment -> unit
+    = "ml_pango_layout_set_alignment"
 end

--- a/src/pango.ml
+++ b/src/pango.ml
@@ -218,4 +218,6 @@ module Layout = struct
     = "ml_pango_layout_set_ellipsize"
   external get_ellipsize : layout -> ellipsize_mode
     = "ml_pango_layout_get_ellipsize"
+  external get_baseline : layout -> int = "ml_pango_layout_get_baseline"
+  external get_line_count : layout -> int = "ml_pango_layout_get_line_count"
 end

--- a/src/pango.ml
+++ b/src/pango.ml
@@ -220,4 +220,6 @@ module Layout = struct
     = "ml_pango_layout_get_ellipsize"
   external get_baseline : layout -> int = "ml_pango_layout_get_baseline"
   external get_line_count : layout -> int = "ml_pango_layout_get_line_count"
+  external is_wrapped : layout -> bool = "ml_pango_layout_is_wrapped"
+  external is_ellipsized : layout -> bool = "ml_pango_layout_is_ellipsized"
 end

--- a/src/pango_tags.var
+++ b/src/pango_tags.var
@@ -35,3 +35,6 @@ type wrap_mode = "PANGO_WRAP_"
 type protect HASGTK26 ellipsize_mode = "PANGO_ELLIPSIZE_"
   [ `NONE | `START | `MIDDLE | `END ]
 (* this enum was introduced in Pango 1.6 / GTK+ 2.6 *)
+
+type alignment = "PANGO_ALIGN_"
+  [ `LEFT | `CENTER | `RIGHT ]


### PR DESCRIPTION
Additions to Pango module:

```ocaml
module Tags : sig
  ....
  type alignment = [ `LEFT | `CENTER | `RIGHT ]
end

module Layout : sig
  ....
  val get_baseline   : layout -> int
  val get_line_count : layout -> int
  val is_wrapped     : layout -> bool
  val is_ellipsized  : layout -> bool
  val get_alignment  : layout -> alignment
  val set_alignment  : layout -> alignment -> unit
end
```