### PR TITLE
Fixup mli for Gdk.Window.get_origin.

### DIFF
--- a/src/gdk.mli
+++ b/src/gdk.mli
@@ -315,6 +315,7 @@ module Window :
     val create_foreign : display -> xid -> window
     val get_parent : window -> window
     val get_position : window -> int * int
+    val get_origin : window -> int * int
     val get_pointer_location : window -> int * int
     (* val root_parent : unit -> window
     val clear : window -> unit


### PR DESCRIPTION
For some reason the PR I submitted (#60) did not contain the mli change.