### PR TITLE
[dune] Build support for pango_cairo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 LablGTK changes log
 
+## In Lablgtk-3.0.beta7
+
+2019.07.07 [Emilio]
+  * Include extended Cairo Support from #33 in the Dune build.
+
 ## In Lablgtk-3.0.beta6
 
 2019.04.09 [Jacques]

--- a/examples/cairo_demo.ml
+++ b/examples/cairo_demo.ml
@@ -40,6 +40,7 @@ let expose drawing_area cr =
   true
 
 let () =
+  let _ = GMain.Main.init () in
   let w = GWindow.window ~title:"Cairo demo" ~width:500 ~height:400 () in
   ignore(w#connect#destroy ~callback:GMain.quit);
 

--- a/examples/dune
+++ b/examples/dune
@@ -6,7 +6,7 @@
    action ; assistant
    assistant_tutorial
    ; buttons
-   calc calendar cgets ; clist
+   cairo_demo calc calendar cgets ; clist
    combobox ; combo counter dcalendar
    dialog-thread drawing ; druid
    editor2 ; editor
@@ -16,6 +16,7 @@
    gioredirect giotest hello iconview ; image kaimono
    ; label link_button lissajous
    nihongo notebook
+   pango1 pango2
    ; pixview pousse
    progressbar radiobuttons ; rpn
    ; runthread
@@ -27,7 +28,8 @@
  )
  (modules
    about accel_tree action assistant assistant_tutorial
-   buttons calc calendar cgets clist combobox combo counter
+   buttons cairo_demo
+   calc calendar cgets clist combobox combo counter
    dcalendar dialog-thread drawing druid
    editor2 editor
    entry2 entrycompletion entry eventbox events2 events expander
@@ -35,7 +37,7 @@
    gioredirect giotest hello iconview image kaimono
    label link_button lissajous
    nihongo notebook
-   pixview pousse progressbar radiobuttons rpn
+   pango1 pango2 pixview pousse progressbar radiobuttons rpn
    runthread
    scrolledwin seppala signal_override slide_show socket spin
    testdnd ; testgtk

--- a/examples/pango1.ml
+++ b/examples/pango1.ml
@@ -59,6 +59,7 @@ let expose drawing_area cr =
   true
 
 let () =
+  let _ = GMain.Main.init () in
   let w = GWindow.window ~title:"Pango demo1" ~width:500 ~height:400 () in
   ignore(w#connect#destroy ~callback:GMain.quit);
 

--- a/examples/pango2.ml
+++ b/examples/pango2.ml
@@ -46,6 +46,7 @@ let expose drawing_area cr =
   true
 
 let () =
+  let _ = GMain.Main.init () in
   let w = GWindow.window ~title:"Pango demo2" ~width:500 ~height:400 () in
   ignore(w#connect#destroy ~callback:GMain.quit);
 

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
-; Dune build file for lablgtk2
+; Dune build file for lablgtk3
 ; Written by EJGA, (c) 2018 MINES ParisTech
 ; This file is in the public domain
 
@@ -85,6 +85,7 @@
    gtkWindow gWindow
    gtkData gData
    gContainer
+   gPango cairo_pango
 
    gtkBuilderProps    ogtkBuilderProps    gtkBuilder   gBuilder
    gtkContainersProps ogtkContainersProps gtkContainers
@@ -108,6 +109,7 @@
    wrappers
    ml_glib ml_gvaluecaml ml_gpointer ml_gobject
    ml_pango
+   cairo_pango_stubs
    ml_gdk ml_gdkpixbuf
    ml_gtk ml_gtkmisc
 


### PR DESCRIPTION
Fixes #71 ; the support for `pango_cairo` was added in #33, however
Dune support was done for a branch without that modules, thus they were
not included in the build.

We just add the pango_cairo modules and stubs to the dune build.