### PR TITLE
Remove declaration of young_start for ocaml 4.10

### DIFF
--- a/src/ml_gtktree.c
+++ b/src/ml_gtktree.c
@@ -1151,9 +1151,9 @@ encode_iter(Custom_model *custom_model, GtkTreeIter *iter, value v)
   /* Ideally, the user would already have ensured all these were stable...
      and in any case, it is always up to the user to ensure that they will
      not get garbage collected */
-    if((Is_block(v1) && (char*)v1 < (char*)caml_young_end && (char*)v1 > (char*)caml_young_start) ||
-       (Is_block(v2) && (char*)v2 < (char*)caml_young_end && (char*)v2 > (char*)caml_young_start) ||
-       (Is_block(v3) && (char*)v3 < (char*)caml_young_end && (char*)v3 > (char*)caml_young_start))
+    if((Is_block(v1) && (char*)v1 < (char*)young_end && (char*)v1 > (char*)young_start) ||
+       (Is_block(v2) && (char*)v2 < (char*)young_end && (char*)v2 > (char*)young_start) ||
+       (Is_block(v3) && (char*)v3 < (char*)young_end && (char*)v3 > (char*)young_start))
       {
 	caml_register_global_root (&v1);
 	caml_register_global_root (&v2);

--- a/src/wrappers.h
+++ b/src/wrappers.h
@@ -33,7 +33,10 @@
 #include <caml/mlvalues.h>
 #include <caml/fail.h>
 #include <caml/custom.h>
+#include <caml/version.h>
+#if OCAML_VERSION < 41000
 CAMLextern char *young_start, *young_end; /* from minor_gc.h */
+#endif
 
 CAMLexport value copy_memblock_indirected (void *src, asize_t size);
 value alloc_memblock_indirected (asize_t size);


### PR DESCRIPTION
* Fix the `wrappers.h` part of #92 by making the re-declaration of `young_start` and `young_end` conditional on ocaml version older than 4.10.
* Replace `caml_young_{start,end}` by `young_*` in `ml_gtktree.c` to work around bug in pre-release 4.10.