### PR TITLE
[travis] Fix OSX build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,11 @@ matrix:
       before_install: |
         set -e
         brew update
-        brew install wget ccache opam pkg-config gtk+3 gtksourceview3 gtkspell3
+        brew upgrade wget
+        brew install curl ccache opam pkg-config gtk+3 gtksourceview3 gtkspell3
 
 before_install: |
-  sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.4/opam-2.0.4-x86_64-linux -o /usr/bin/opam
+  sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.5/opam-2.0.5-x86_64-linux -o /usr/bin/opam
   sudo chmod 755 /usr/bin/opam
 
 install: |


### PR DESCRIPTION
Brew recipe for OPAM turns out to be problematic [certificate
problems] so we install directly from the upstream binary package.