### PR TITLE
[build] Use newer configurator API, correct build-deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ before_install: |
 install: |
   opam init --bare --disable-sandboxing
   opam repo add -a beta https://github.com/ocaml/ocaml-beta-repository.git
-  opam switch create "$COMPILER" --repositories=default,beta
+  opam switch create "$COMPILER" --repositories=default,beta || true
   opam switch set "$COMPILER"
   eval $(opam env)
   opam install $BASE_OPAM

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ LablGTK changes log
   * remove declaration of young_start for ocaml 4.10 (#97)
   * add CI support for 4.10 [Emilio]
 
+2019.11.26 [Emilio]
+  * Require Dune 1.8, use improved configurator API (#95)
+
 ## In Lablgtk-3.0beta7
 
 2019.11.25 [Jacques]

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.6)
+(lang dune 1.8)
 (name lablgtk3)

--- a/lablgtk3-gtkspell3.opam
+++ b/lablgtk3-gtkspell3.opam
@@ -17,11 +17,9 @@ doc: "https://garrigue.github.io/lablgtk/lablgtk3-gtkspell3"
 license: "LGPL with linking exception"
 
 depends: [
-  "ocaml"                {         >= "4.05.0"    }
-  "dune"                 { build & >= "1.6.0"
-                                 & != "1.7.0"
-                                 & != "1.7.1"     } # Due to dune/dune#1833
-  "lablgtk3"             {         >= "3.0.beta5" }
+  "ocaml"                { >= "4.05.0"    }
+  "dune"                 { >= "1.8.0"     }
+  "lablgtk3"             { >= "3.0.beta6" }
 ]
 depexts: [
   ["gtkspell3-dev"] {os-distribution = "alpine"}

--- a/lablgtk3-sourceview3.opam
+++ b/lablgtk3-sourceview3.opam
@@ -17,10 +17,8 @@ license: "LGPL with linking exception"
 
 depends: [
   "ocaml"                {         >= "4.05.0"    }
-  "dune"                 { build & >= "1.6.0"
-                                 & != "1.7.0"
-                                 & != "1.7.1"     } # Due to dune/dune#1833
-  "lablgtk3"             {         >= "3.0.beta5" }
+  "dune"                 {         >= "1.8.0"     }
+  "lablgtk3"             {         >= "3.0.beta6" }
   "conf-gtksourceview3"  { build & >= "0"         }
 ]
 

--- a/lablgtk3.opam
+++ b/lablgtk3.opam
@@ -17,11 +17,9 @@ doc: "https://garrigue.github.io/lablgtk/lablgtk3"
 
 depends: [
   "ocaml"     {         >= "4.05.0" }
-  "dune"      { build & >= "1.6.0"
-                      & != "1.7.0"
-                      & != "1.7.1"  } # Due to dune/dune#1833
-  "conf-gtk3" { build & >= "18"     }
+  "dune"      {         >= "1.8.0"  }
   "cairo2"    {         >= "0.6"    }
+  "conf-gtk3" { build & >= "18"     }
 ]
 
 build: [

--- a/tools/dune_config.ml
+++ b/tools/dune_config.ml
@@ -2,7 +2,7 @@ module C = Configurator.V1
 
 (* XXX: Use `die` *)
 let error str =
-  Format.eprintf "configure error: %s.@\n%!" str;
+  Format.eprintf "configure error: %s@\n%!" str;
   exit 1
 
 module Option = struct
@@ -19,22 +19,23 @@ end
 let platform_subst p ~package =
   match package with
   | "gtk+-3.0" ->
-    Option.cata
-      ~f:(fun _ -> "gtk+-quartz-3.0", ["-DHAS_GTKQUARTZ"])
-      (package,[])
-      C.Pkg_config.(query p ~package:"gtk+-quartz-3.0")
+    (match C.Pkg_config.query p ~package:"gtk+-quartz-3.0" with
+     | Some _ -> "gtk+-quartz-3.0", ["-DHAS_GTKQUARTZ"]
+     | None -> package, [])
   | _ ->
     package, []
 
-let query_pkg p ~package =
-  Option.require ~message:(package ^ " not found") C.Pkg_config.(query p ~package)
+let query_pkg p ~package ~expr =
+  match C.Pkg_config.query_expr_err p ~package ~expr with
+  | Ok s -> s
+  | Error e -> error e
 
 let gen_pkg p ~package ~version =
   let file kind = kind ^ "-" ^ package ^ ".sexp" in
   let package, extra_flags = platform_subst p ~package in
-  let package =
-    Option.cata ~f:(fun version -> Format.sprintf "%s >= %s" package version) package version in
-  let c_g = query_pkg p ~package in
+  let expr =
+    Option.cata ~f:(fun version -> Format.sprintf "%s >= %s" package version) "" version in
+  let c_g = query_pkg p ~package ~expr in
   C.Flags.write_sexp (file "cflag") @@ c_g.C.Pkg_config.cflags @ extra_flags;
   C.Flags.write_sexp (file "clink") c_g.C.Pkg_config.libs
 


### PR DESCRIPTION
We use the new configurator API which does provide better error
messages and avoids some warnings during build. This means we have to
bump to dune 1.8.0 but that should not be a problem these days.

We also correct the opam files as to remove the `build` dune flag [as
per upstream policy], and require a strict matching on the version
field for depending packages [safer and few downsides]