### PR TITLE
[gtkdoc] Test gtkdoc compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
   - OPAMROOTISOK="true"
   - OPAMYES="true"
   - COMPILER="4.07.1"
-  - BASE_OPAM="camlp5 dune cairo2"
+  - BASE_OPAM="camlp5 dune cairo2 ocamlfind"
 
   # Main test suite, some examples don't work in 4.05.0
   matrix:

--- a/tools/dune
+++ b/tools/dune
@@ -24,3 +24,8 @@
  (name dune_config)
  (modules dune_config)
  (libraries dune.configurator))
+
+(library
+ (name gtkdoc)
+ (modules gtkdoc)
+ (libraries str ocamldoc))


### PR DESCRIPTION
We enable compilation of gtkdoc and test it. In the future we could
add an ocamldoc rule to resurrect the documentation build with Dune.

It would maybe be worth porting this to `odoc`.