### PR TITLE
remove declaration of young_start for ocaml 4.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,22 @@
 dist: xenial
 sudo: required
 language: c
+
+branches:
+  only:
+  - lablgtk3
+
 cache:
   apt: true
   directories:
   - $HOME/.opam
+
 addons:
   apt:
     packages:
     - libgtksourceview-3.0-dev
     - libgtkspell3-3-dev
+
 env:
   global:
   - OPAMJOBS="2"
@@ -25,6 +32,7 @@ env:
   - TEST_TARGET="build-all"   COMPILER="4.07.1"
   - TEST_TARGET="build-all"   COMPILER="4.08.0"
   - TEST_TARGET="build-all"   COMPILER="4.09.0"
+  - TEST_TARGET="nopromote"   COMPILER="4.10.0+trunk"
   - TEST_TARGET="opam"        COMPILER="4.07.1"
   - TEST_TARGET="opam"        COMPILER="4.08.0"
   - TEST_TARGET="opam"        COMPILER="4.09.0"
@@ -53,7 +61,9 @@ before_install: |
   sudo chmod 755 /usr/bin/opam
 
 install: |
-  opam init -c "$COMPILER" --disable-sandboxing
+  opam init --bare --disable-sandboxing
+  opam repo add -a beta https://github.com/ocaml/ocaml-beta-repository.git
+  opam switch create "$COMPILER" --repositories=default,beta
   opam switch set "$COMPILER"
   eval $(opam env)
   opam install $BASE_OPAM

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 LablGTK changes log
 
+2019.11.27 [Jacques]
+  * remove declaration of young_start for ocaml 4.10 (#97)
+
 ## In Lablgtk-3.0beta7
 
 2019.11.25 [Jacques]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ LablGTK changes log
 
 2019.11.27 [Jacques]
   * remove declaration of young_start for ocaml 4.10 (#97)
+  * add CI support for 4.10 [Emilio]
 
 ## In Lablgtk-3.0beta7
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-all opam clean
+.PHONY: build build-all nopromote opam clean
 
 build:
 	dune build
@@ -6,6 +6,9 @@ build:
 # This also builds examples
 build-all:
 	dune build @all
+
+nopromote:
+	dune build @all --ignore-promoted-rules
 
 # We first pin lablgtk3 as to avoid problems with parallel make
 opam:

--- a/src/ml_gtktree.c
+++ b/src/ml_gtktree.c
@@ -1148,9 +1148,9 @@ encode_iter(Custom_model *custom_model, GtkTreeIter *iter, value v)
   /* Ideally, the user would already have ensured all these were stable...
      and in any case, it is always up to the user to ensure that they will
      not get garbage collected */
-    if((Is_block(v1) && (char*)v1 < (char*)caml_young_end && (char*)v1 > (char*)caml_young_start) ||
-       (Is_block(v2) && (char*)v2 < (char*)caml_young_end && (char*)v2 > (char*)caml_young_start) ||
-       (Is_block(v3) && (char*)v3 < (char*)caml_young_end && (char*)v3 > (char*)caml_young_start))
+    if((Is_block(v1) && (char*)v1 < (char*)young_end && (char*)v1 > (char*)young_start) ||
+       (Is_block(v2) && (char*)v2 < (char*)young_end && (char*)v2 > (char*)young_start) ||
+       (Is_block(v3) && (char*)v3 < (char*)young_end && (char*)v3 > (char*)young_start))
       {
 	caml_register_global_root (&v1);
 	caml_register_global_root (&v2);

--- a/src/ml_gtktree.c
+++ b/src/ml_gtktree.c
@@ -1486,8 +1486,8 @@ CAMLprim value ml_register_custom_model_callback_object(value custom_model,
   GObject *obj = GObject_val(custom_model);
   g_return_val_if_fail (IS_CUSTOM_MODEL (obj),Val_unit);
   if(Is_block(callback_object) &&
-      (char*)callback_object < (char*)caml_young_end &&
-      (char*)callback_object > (char*)caml_young_start)
+      (char*)callback_object < (char*)young_end &&
+      (char*)callback_object > (char*)young_start)
     {
       caml_register_global_root (&callback_object);
       caml_minor_collection();

--- a/src/wrappers.h
+++ b/src/wrappers.h
@@ -33,7 +33,10 @@
 #include <caml/mlvalues.h>
 #include <caml/fail.h>
 #include <caml/custom.h>
+#include <caml/version.h>
+#if OCAML_VERSION < 41000
 CAMLextern char *young_start, *young_end; /* from minor_gc.h */
+#endif
 
 CAMLexport value copy_memblock_indirected (void *src, asize_t size);
 value alloc_memblock_indirected (asize_t size);


### PR DESCRIPTION
Cherry pick #93 for lablgtk3
* do not re-declare young_start and young_end if ocaml version >= 4.10
* use young_start/young_end to work around ocaml PR #9143
