### PR TITLE
[sourceview4] Preliminary support for gtksourceview4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 sudo: required
 language: c
 
@@ -14,6 +14,8 @@ cache:
 addons:
   apt:
     packages:
+    - valac
+    - meson                     # until libgtksourceview-4-dev arrives
     - libgtksourceview-3.0-dev
     - libgtkspell3-3-dev
 
@@ -55,10 +57,14 @@ matrix:
         brew update
         brew upgrade wget
         brew unlink python@2
-        brew install curl ccache opam pkg-config gtk+3 gtksourceview3 gtkspell3
+        brew install curl ccache opam pkg-config gtk+3 gtksourceview3 gtksourceview4 gtkspell3
 
 before_install: |
-  sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.5/opam-2.0.5-x86_64-linux -o /usr/bin/opam
+  curl -sL https://download.gnome.org/sources/gtksourceview/4.2/gtksourceview-4.2.0.tar.xz | tar xvJ
+  pushd gtksourceview-4.2.0 && ./configure && make && sudo make install
+  # pushd gtksourceview-4.2.0 && mkdir build && meson build && (cd build && ninja && sudo ninja install)
+  popd
+  sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.6/opam-2.0.6-x86_64-linux -o /usr/bin/opam
   sudo chmod 755 /usr/bin/opam
 
 install: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 LablGTK changes log
 
+2020.01.18 [Emilio]
+  * Beginnings of gtksourceview4 bindings
+
 2020.01.14 [Jacques]
   * remove GtkDialog#has_separator property (report by Thomas Leonard, #68)
   * add GMisc.icon_status#set_tooltip_markup/text (report by T. Leonard, #69)

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,12 @@ nopromote:
 	dune build @all --ignore-promoted-rules
 
 # We first pin lablgtk3 as to avoid problems with parallel make
+OPAM_PKGS=lablgtk3 lablgtk3-sourceview3 lablgtk3-sourceview4 lablgtk3-gtkspell3
 opam:
-	opam pin add lablgtk3 . --kind=path -y
-	opam install lablgtk3
-	opam pin add lablgtk3-sourceview3 . --kind=path -y
-	opam install lablgtk3-sourceview3
-	opam pin add lablgtk3-gtkspell3 . --kind=path -y
-	opam install lablgtk3-gtkspell3
+	for pkg in $(OPAM_PKGS) ; do \
+		opam pin add $$pkg . --kind=path -y ; \
+		opam install $$pkg ; \
+	done
 
 clean:
 	dune clean

--- a/lablgtk3-sourceview4.opam
+++ b/lablgtk3-sourceview4.opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+ gtksourceview library"
+description: """
+OCaml interface to GTK+3, gtksourceview4 library.
+
+See https://garrigue.github.io/lablgtk/ for more information.
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3-sourceview3"
+license: "LGPL with linking exception"
+
+depends: [
+  "ocaml"                {         >= "4.05.0" }
+  "dune"                 {         >= "1.8.0"  }
+  "lablgtk3"             {          = version  }
+  # "conf-gtksourceview4"  { build & >= "0"      }
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]

--- a/src-sourceview4/dune
+++ b/src-sourceview4/dune
@@ -1,0 +1,37 @@
+; Dune build file for lablgtk3
+; Written by EJGA, (c) 2018-2019 MINES ParisTech
+; This file is in the public domain
+
+(rule
+ (targets sourceView4_tags.h sourceView4_tags.c sourceView4Enums.ml)
+ (action (run varcc %{dep:sourceView4_tags.var})))
+
+(rule
+ (targets gtkSourceView4Props.ml ogtkSourceView4Props.ml)
+ (action (run propcc %{dep:gtkSourceView4.props})))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; lablgtk3-sourceview3                                                 ;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule
+ (targets
+   cflag-gtksourceview-4.sexp
+   clink-gtksourceview-4.sexp)
+ (action (run dune_config -pkg gtksourceview-4 -version 4.2.0)))
+
+(rule
+ (targets cflag-extraflags.sexp)
+ (action (with-outputs-to cflag-extraflags.sexp (echo "(%{env:LABLGTK_EXTRA_FLAGS=})"))))
+
+(library
+ (name lablgtk3_sourceview4)
+ (public_name lablgtk3-sourceview4)
+ (wrapped false)
+ (flags :standard -w -6-7-27-32-33-34-36)
+ (modules_without_implementation gtkSourceView4_types)
+ (c_names ml_gtksourceview4)
+ (c_flags         (:include cflag-gtksourceview-4.sexp) (:include cflag-extraflags.sexp) -Wno-deprecated-declarations)
+ (c_library_flags (:include clink-gtksourceview-4.sexp))
+ (libraries lablgtk3))
+

--- a/src-sourceview4/gSourceView4.ml
+++ b/src-sourceview4/gSourceView4.ml
@@ -1,0 +1,636 @@
+(**************************************************************************)
+(*                Lablgtk                                                 *)
+(*                                                                        *)
+(*    This program is free software; you can redistribute it              *)
+(*    and/or modify it under the terms of the GNU Library General         *)
+(*    Public License as published by the Free Software Foundation         *)
+(*    version 2, with the exception described in file COPYING which       *)
+(*    comes with the library.                                             *)
+(*                                                                        *)
+(*    This program is distributed in the hope that it will be useful,     *)
+(*    but WITHOUT ANY WARRANTY; without even the implied warranty of      *)
+(*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the       *)
+(*    GNU Library General Public License for more details.                *)
+(*                                                                        *)
+(*    You should have received a copy of the GNU Library General          *)
+(*    Public License along with this program; if not, write to the        *)
+(*    Free Software Foundation, Inc., 59 Temple Place, Suite 330,         *)
+(*    Boston, MA 02111-1307  USA                                          *)
+(*                                                                        *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Gaux
+open GtkSourceView4
+open SourceView4Enums
+open Gobject
+open Gtk
+open GtkBase
+open GtkSourceView4_types
+open OgtkSourceView4Props
+open GObj
+
+let get_bool = function `BOOL x -> x | _ -> assert false
+let bool x = `BOOL x
+let get_uint = function `INT x -> x | _ -> assert false
+let uint x = `INT x
+let get_int = function `INT x -> x | _ -> assert false
+let int x = `INT x
+let get_gobject = function `OBJECT x -> x | _ -> assert false
+let gobject x = `OBJECT (Some x)
+
+let map_opt f = function
+    None -> None
+  | Some x -> Some (f x)
+
+(** {2 GtkSourceTag} *)
+
+type source_tag_property = [
+  | `BACKGROUND of Gdk.color
+  | `BOLD of bool
+  | `FOREGROUND of Gdk.color
+  | `ITALIC of bool
+  | `STRIKETHROUGH of bool
+  | `UNDERLINE of bool
+]
+
+let text_tag_property_of_source_tag_property = function
+  | `BACKGROUND p -> `BACKGROUND_GDK p
+  | `BOLD p -> `WEIGHT (if p then `BOLD else `NORMAL)
+  | `FOREGROUND p -> `FOREGROUND_GDK p
+  | `ITALIC p -> `STYLE (if p then `ITALIC else `NORMAL)
+  | `STRIKETHROUGH p -> `STRIKETHROUGH p
+  | `UNDERLINE p -> `UNDERLINE (if p then `SINGLE else `NONE)
+
+(* Gtk.Color deactivated
+let color_of_string s =
+  Gdk.Color.alloc ~colormap: (Gdk.Color.get_system_colormap())
+    (`NAME s)
+*)
+
+(** {2 GtkSourceStyleScheme} *)
+
+class source_style_scheme (obj: GtkSourceView4_types.source_style_scheme obj) =
+object(self)
+  method as_source_style_scheme = obj
+  method name = SourceStyleScheme.get_name obj
+  method description = SourceStyleScheme.get_description obj
+end
+
+
+(** {2 GtkSourceStyleSchemeManager} *)
+
+class source_style_scheme_manager
+	(obj: GtkSourceView4_types.source_style_scheme_manager obj) =
+  object(self)
+    val obj = obj
+    inherit source_style_scheme_manager_props
+
+    method search_path =
+      SourceStyleSchemeManager.get_search_path obj
+    method set_search_path =
+      SourceStyleSchemeManager.set_search_path obj
+    method style_scheme_ids =
+      SourceStyleSchemeManager.get_scheme_ids obj
+    method style_scheme s =
+      may_map (new source_style_scheme)
+	(SourceStyleSchemeManager.get_scheme obj s)
+  end
+
+let source_style_scheme_manager ~default =
+  let mgr =
+    if default then SourceStyleSchemeManager.default ()
+    else SourceStyleSchemeManager.new_ () in
+  new source_style_scheme_manager mgr
+
+(** {2 GtkSourceCompletionInfo} *)
+
+class source_completion_info_signals
+  (obj' : GtkSourceView4_types.source_completion_info obj) =
+  object
+    inherit GContainer.container_signals_impl obj'
+    inherit source_completion_info_sigs
+  end
+
+class source_completion_info 
+  (obj' : ([> GtkSourceView4_types.source_completion_info ] as 'a) obj) =
+  object
+    inherit GWindow.window obj'
+    inherit source_completion_info_props
+    method as_source_completion_info =
+      (obj :> GtkSourceView4_types.source_completion_info obj)
+    (* method widget = new GObj.widget (SourceCompletionInfo.get_widget obj)
+     * method set_widget (w : GObj.widget) = SourceCompletionInfo.set_widget obj w#as_widget *)
+  end
+
+(** {2 GtkSourceCompletionProposal} *)
+
+class source_completion_proposal_signals
+  (obj' : GtkSourceView4_types.source_completion_proposal obj) =
+  object
+    inherit ['a] gobject_signals (obj' : [> GtkSourceView4_types.source_completion_proposal ] obj)
+    inherit source_completion_proposal_sigs
+  end
+
+class source_completion_proposal 
+  (obj : GtkSourceView4_types.source_completion_proposal obj) =
+  object
+    val obj = obj
+    method connect = new source_completion_proposal_signals obj
+    method as_source_completion_proposal = obj
+    inherit source_completion_proposal_props
+  end
+
+class source_completion_item
+  (obj : GtkSourceView4_types.source_completion_proposal obj) =
+  object
+    inherit source_completion_proposal obj
+    inherit source_completion_item_props
+  end
+
+let source_completion_item ?(label = "") ?(text = "") ?icon ?info () =
+  new source_completion_item (SourceCompletionItem.new_ label text icon info)
+
+(* let source_completion_item_with_markup ?(label = "") ?(text = "") ?icon ?info () =
+ *   new source_completion_item (SourceCompletionItem.new_with_markup label text icon info) *)
+
+(* let source_completion_item_from_stock ?(label = "") ?(text = "") ~stock ~info () =
+ *   let stock = GtkStock.Item.lookup stock in
+ *   let id = stock.GtkStock.stock_id in
+ *   new source_completion_item (SourceCompletionItem.new_from_stock label text id info) *)
+
+(** {2 GtkSourceCompletionProvider} *)
+
+class source_completion_provider
+  (obj' : GtkSourceView4_types.source_completion_provider obj) =
+  object
+    val obj = obj'
+    method as_source_completion_provider = obj
+    method icon = SourceCompletionProvider.get_icon obj
+    method name = SourceCompletionProvider.get_name obj
+    method populate (context : source_completion_context) =
+      SourceCompletionProvider.populate obj context#as_source_completion_context
+    method activation =
+      SourceCompletionProvider.get_activation obj
+    method matched (context : source_completion_context) =
+      SourceCompletionProvider.match_ obj context#as_source_completion_context
+    method info_widget (proposal : source_completion_proposal) =
+      let widget = SourceCompletionProvider.get_info_widget obj proposal#as_source_completion_proposal in
+      match widget with
+      | None -> None
+      | Some widget -> Some (new GObj.widget widget)
+    method update_info (proposal : source_completion_proposal) (info : source_completion_info) =
+      SourceCompletionProvider.update_info obj proposal#as_source_completion_proposal info#as_source_completion_info
+    method start_iter (context : source_completion_context) (proposal : source_completion_proposal) =
+      let iter = 
+        SourceCompletionProvider.get_start_iter obj
+          context#as_source_completion_context proposal#as_source_completion_proposal 
+      in
+      new GText.iter iter
+
+    method activate_proposal (proposal : source_completion_proposal) (iter : GText.iter) =
+      SourceCompletionProvider.activate_proposal obj proposal#as_source_completion_proposal iter#as_iter
+
+    method interactive_delay =
+      SourceCompletionProvider.get_interactive_delay obj 
+
+    method priority =
+      SourceCompletionProvider.get_priority obj 
+
+  end
+
+(** {2 GtkSourceCompletionContext} *)
+
+and source_completion_context_signals
+  (obj' : GtkSourceView4_types.source_completion_context obj) =
+  object
+    inherit ['a] gobject_signals (obj' : [> GtkSourceView4_types.source_completion_context ] obj)
+    inherit source_completion_context_sigs
+  end
+
+and source_completion_context
+  (obj' : GtkSourceView4_types.source_completion_context obj) =
+  object
+    val obj = obj'
+    val iter_prop = {
+      Gobject.name = "iter";
+      conv = Gobject.Data.unsafe_pointer
+    }
+    inherit source_completion_context_props
+    method as_source_completion_context = obj
+    method activation = SourceCompletionContext.get_activation obj
+    method add_proposals
+      (provider : source_completion_provider) (proposals : source_completion_proposal list) b =
+      let proposals = List.map (fun obj -> obj#as_source_completion_proposal) proposals in
+      SourceCompletionContext.add_proposals obj
+      provider#as_source_completion_provider proposals b
+    method connect = new source_completion_context_signals obj'
+    method iter =
+      new GText.iter (Gobject.get iter_prop obj)
+
+    method set_iter (iter : GText.iter) =
+      Gobject.set iter_prop obj (iter#as_iter)
+  end
+
+class type custom_completion_provider =
+  object
+    method name : string
+    method icon : GdkPixbuf.pixbuf option
+    method populate : source_completion_context -> unit
+    method matched : source_completion_context -> bool
+    method activation : source_completion_activation_flags list
+    method info_widget : source_completion_proposal -> GObj.widget option
+    method update_info : source_completion_proposal -> source_completion_info -> unit
+    method start_iter : source_completion_context -> source_completion_proposal -> GText.iter -> bool
+    method activate_proposal : source_completion_proposal -> GText.iter -> bool
+    method interactive_delay : int
+    method priority : int
+  end
+
+let source_completion_provider (p : custom_completion_provider) : source_completion_provider =
+  let of_context ctx = new source_completion_context ctx in
+  let of_proposal prop = new source_completion_proposal prop in
+  let of_info info = new source_completion_info info in
+  let of_iter iter = new GText.iter iter in
+  let as_opt_widget = function
+  | None -> None
+  | Some obj -> Some obj#as_widget
+  in
+  let completion_provider = {
+    SourceCompletionProvider.provider_name = (fun () -> p#name);
+    provider_icon = (fun () -> p#icon);
+    provider_populate = (fun ctx -> p#populate (of_context ctx));
+    provider_match = (fun ctx -> p#matched (of_context ctx));
+    provider_activation = (fun () -> p#activation);
+    provider_info_widget = (fun prop -> as_opt_widget (p#info_widget (of_proposal prop)));
+    provider_update_info = (fun prop info -> p#update_info (of_proposal prop) (of_info info));
+    provider_start_iter = (fun ctx prop iter -> p#start_iter (of_context ctx) (of_proposal prop) (of_iter iter));
+    provider_activate_proposal = (fun prop iter -> p#activate_proposal (of_proposal prop) (of_iter iter));
+    provider_interactive_delay = (fun () -> p#interactive_delay);
+    provider_priority = (fun () -> p#priority);
+  } in
+  let obj = SourceCompletionProvider.new_ completion_provider in
+  new source_completion_provider obj
+
+(** {2 GtkSourceCompletion} *)
+
+class source_completion_signals obj' =
+object (self)
+  inherit ['a] gobject_signals (obj' : [> GtkSourceView4_types.source_completion] obj)
+  inherit source_completion_sigs
+  method populate_context ~callback =
+    let callback obj = callback (new source_completion_context obj) in
+    self#connect SourceCompletion.S.populate_context ~callback
+end
+
+class source_completion
+  (obj : GtkSourceView4_types.source_completion obj) =
+  object
+    val obj = obj
+    inherit source_completion_props as super
+    method as_source_completion = obj
+    method connect = new source_completion_signals obj
+
+    method create_context (iter : GText.iter) =
+      let obj = SourceCompletion.create_context obj (iter#as_iter) in
+      new source_completion_context obj
+
+    (* method move_window (iter : GText.iter) =
+     *   SourceCompletion.move_window obj (iter#as_iter) *)
+
+    (* method show (prs : source_completion_provider list) (ctx : source_completion_context) =
+     *   let prs = List.map (fun pr -> pr#as_source_completion_provider) prs in
+     *   SourceCompletion.show obj prs ctx#as_source_completion_context *)
+
+    method providers =
+      let prs = SourceCompletion.get_providers obj in
+      List.map (fun pr -> new source_completion_provider pr) prs
+
+    method add_provider (pr : source_completion_provider) =
+      SourceCompletion.add_provider obj (pr#as_source_completion_provider)
+
+    method remove_provider (pr : source_completion_provider) =
+      SourceCompletion.remove_provider obj (pr#as_source_completion_provider)
+
+  end
+
+(** {2 GtkSourceLanguage} *)
+
+class source_language (obj: GtkSourceView4_types.source_language obj) =
+object (self)
+  method as_source_language = obj
+  val obj = obj
+  method misc = new gobject_ops obj
+
+  method id = SourceLanguage.get_id obj
+  method name = SourceLanguage.get_name obj
+  method section = SourceLanguage.get_section obj
+  method hidden = SourceLanguage.get_hidden obj
+
+  method metadata s = SourceLanguage.metadata obj s
+  method mime_types = SourceLanguage.mime_types obj
+  method globs = SourceLanguage.globs obj
+  method style_name s = SourceLanguage.style_name obj s
+  method style_ids = SourceLanguage.style_ids obj
+end
+
+(** {2 GtkSourceLanguageManager} *)
+
+class source_language_manager
+  (obj: GtkSourceView4_types.source_language_manager obj) =
+object (self)
+  method get_oid = Gobject.get_oid obj
+  method as_source_language_manager = obj
+
+  method set_search_path p = SourceLanguageManager.set_search_path obj p
+  method search_path = SourceLanguageManager.search_path obj
+  method language_ids = SourceLanguageManager.language_ids obj
+
+  method language id =
+    may_map
+      (new source_language)
+      (SourceLanguageManager.language obj id )
+
+  method guess_language ?filename ?content_type () =
+    may_map
+      (new source_language)
+      (SourceLanguageManager.guess_language obj filename content_type)
+end
+
+let source_language_manager ~default =
+  new source_language_manager
+    (if default then SourceLanguageManager.default ()
+     else SourceLanguageManager.create [])
+
+
+(** {2 GtkSourceMark} *)
+
+class source_mark  (obj: GtkSourceView4_types.source_mark obj) =
+object (self)
+  method coerce = (`MARK (GtkText.Mark.cast obj):GText.mark)
+  method as_source_mark = obj
+  val obj = obj
+  inherit source_mark_props
+
+  method next ?category () =
+    may_map (fun m -> new source_mark m) (SourceMark.next obj category)
+  method prev ?category () =
+    may_map (fun m -> new source_mark m) (SourceMark.prev obj category)
+
+end
+
+let source_mark ?category () =
+  new source_mark (SourceMark.create ?category [])
+
+(** {2 GtkSourceMarkAttributes} *)
+
+class source_mark_attributes (obj: GtkSourceView4_types.source_mark_attributes obj)
+=
+object (self)
+  method as_source_mark_attributes = obj
+  val obj = obj
+  inherit source_mark_attributes_props
+end
+
+let source_mark_attributes () =
+  let obj = SourceMarkAttributes.create [] in
+  new source_mark_attributes obj
+
+(** {2 GtkSourceUndoManager} *)
+
+class source_undo_manager_signals obj' =
+object (self)
+  inherit ['a] gobject_signals (obj' : [> GtkSourceView4_types.source_undo_manager] obj)
+  inherit source_undo_manager_sigs
+end
+
+class source_undo_manager
+  (obj : GtkSourceView4_types.source_undo_manager obj) =
+  object
+    val obj = obj
+    inherit source_undo_manager_props
+    method as_source_undo_manager = obj
+    method connect = new source_undo_manager_signals obj
+  end
+
+class type custom_undo_manager =
+  object
+    method can_undo : bool
+    method can_redo : bool
+    method undo : unit -> unit
+    method redo : unit -> unit
+    method begin_not_undoable_action : unit -> unit
+    method end_not_undoable_action : unit -> unit
+    method can_undo_changed : unit -> unit
+    method can_redo_changed : unit -> unit
+  end
+
+let source_undo_manager (manager : custom_undo_manager) : source_undo_manager =
+  let undo_manager = {
+    SourceUndoManager.can_undo = (fun () -> manager#can_undo);
+    can_redo = (fun () -> manager#can_redo);
+    undo = manager#undo;
+    redo = manager#redo;
+    begin_not_undoable_action = manager#begin_not_undoable_action;
+    end_not_undoable_action = manager#end_not_undoable_action;
+    can_undo_changed = manager#can_undo_changed;
+    can_redo_changed = manager#can_redo_changed;
+  } in
+  let obj = SourceUndoManager.new_ undo_manager in
+  new source_undo_manager obj
+
+(** {2 GtkSourceBuffer} *)
+
+class source_buffer_signals obj' =
+object
+  inherit ['a] gobject_signals (obj' : [> GtkSourceView4_types.source_buffer] obj)
+  inherit GText.buffer_signals_skel
+  inherit source_buffer_sigs
+end
+
+and source_buffer (_obj: GtkSourceView4_types.source_buffer obj) =
+object (self)
+  inherit GText.buffer_skel _obj as text_buffer
+  val obj = _obj
+  method private obj = _obj
+  inherit source_buffer_props
+  method as_source_buffer = obj
+  method connect = new source_buffer_signals obj
+  method misc = new gobject_ops obj
+  method language = may_map (new source_language) (get SourceBuffer.P.language obj)
+  method set_language (l:source_language option) =
+    set SourceBuffer.P.language obj
+      (may_map (fun l -> l#as_source_language) l)
+
+  method style_scheme =
+    may_map (new source_style_scheme) (get SourceBuffer.P.style_scheme obj)
+  method set_style_scheme (s:source_style_scheme option) =
+      match s with
+        None -> ()
+      | Some scheme -> set SourceBuffer.P.style_scheme obj
+          (Some scheme#as_source_style_scheme)
+
+  method undo () = SourceBuffer.undo obj
+  method redo () = SourceBuffer.redo obj
+  method begin_not_undoable_action () =
+    SourceBuffer.begin_not_undoable_action obj
+  method end_not_undoable_action () =
+    SourceBuffer.end_not_undoable_action obj
+
+  method create_source_mark ?name ?category (iter:GText.iter) =
+    new source_mark(SourceBuffer.create_source_mark obj name category iter#as_iter)
+
+  method source_marks_at_line ?category line =
+    List.map
+      (fun mark -> new source_mark mark)
+      (SourceBuffer.get_source_marks_at_line obj line category)
+
+  method source_marks_at_iter ?category (iter:GText.iter) =
+    List.map
+      (fun mark -> new source_mark mark)
+      (SourceBuffer.get_source_marks_at_iter obj iter#as_iter category)
+
+  method remove_source_marks ?category ~(start:GText.iter) ~(stop:GText.iter) () =
+    SourceBuffer.remove_source_marks obj start#as_iter stop#as_iter category
+
+  method forward_iter_to_source_mark ?category (iter:GText.iter) =
+    SourceBuffer.forward_iter_to_source_mark obj iter#as_iter category
+
+  method backward_iter_to_source_mark ?category (iter:GText.iter) =
+    SourceBuffer.backward_iter_to_source_mark obj iter#as_iter category
+
+  method iter_has_context_class (iter:GText.iter) context_class =
+    SourceBuffer.iter_has_context_class obj iter#as_iter context_class
+
+  method iter_forward_to_context_class_toggle (iter:GText.iter) context_class =
+    SourceBuffer.iter_forward_to_context_class_toggle obj iter#as_iter context_class
+
+  method iter_backward_to_context_class_toggle (iter:GText.iter) context_class =
+    SourceBuffer.iter_backward_to_context_class_toggle obj iter#as_iter context_class
+
+  method ensure_highlight ~(start:GText.iter) ~(stop:GText.iter) =
+    SourceBuffer.ensure_highlight obj start#as_iter stop#as_iter
+
+  method set_undo_manager (manager : source_undo_manager) =
+    let manager = manager#as_source_undo_manager in
+    Gobject.set SourceBuffer.P.undo_manager obj manager
+
+  method undo_manager =
+    let manager = Gobject.get SourceBuffer.P.undo_manager obj in
+    new source_undo_manager manager
+
+end
+
+let source_buffer ?(language:source_language option)
+  ?(style_scheme:source_style_scheme option)
+  ?(tag_table : GText.tag_table option) ?text ?(undo_manager : source_undo_manager option)  =
+  let language =
+    match language with
+    | None -> None
+    | Some source_language -> Some (source_language#as_source_language)
+  in
+  let style_scheme =
+    match style_scheme with
+    | None -> None
+    | Some schm -> Some (schm#as_source_style_scheme)
+  in
+  let undo_manager =
+    match undo_manager with
+    | None -> None
+    | Some manager -> Some (manager#as_source_undo_manager)
+  in
+  SourceBuffer.make_params [] ?language ?style_scheme ?undo_manager
+    ~cont:(fun pl () ->
+      let buf =
+	match tag_table with
+	  None ->
+	    new source_buffer (SourceBuffer.create pl)
+	| Some tt ->
+	    let obj = SourceBuffer.new_ tt#as_tag_table in
+	    Gobject.set_params (Gobject.try_cast obj "GtkSourceBuffer") pl;
+	    new source_buffer obj
+      in
+      (match text with
+      | None -> ()
+      | Some text -> buf#set_text text);
+      buf)
+
+(** {2 GtkSourceView} *)
+
+class source_view_signals obj' =
+object
+  inherit widget_signals_impl (obj' : [> GtkSourceView4_types.source_view] obj)
+  inherit GText.view_signals obj'
+  inherit source_view_sigs
+end
+
+class source_view (obj': GtkSourceView4_types.source_view obj) =
+object (self)
+  inherit GText.view_skel obj'
+  inherit source_view_props
+
+  val source_buf =
+    let buf_obj =
+      Gobject.try_cast (GtkText.View.get_buffer obj') "GtkSourceBuffer"
+    in
+    new source_buffer buf_obj
+  method source_buffer = source_buf
+  method connect = new source_view_signals obj'
+
+  method set_cursor_color = SourceView.set_cursor_color obj
+(*  method set_cursor_color_by_name s = SourceView.set_cursor_color obj (color_of_string s)*)
+
+  (* method draw_spaces = SourceView.get_draw_spaces obj
+   * method set_draw_spaces flags = SourceView.set_draw_spaces obj flags *)
+
+  method completion = new source_completion (SourceView.get_completion obj)
+
+  method set_mark_attributes ~category (attrs: source_mark_attributes) priority =
+    SourceView.set_mark_attributes
+      obj ~category attrs#as_source_mark_attributes priority
+
+  method get_mark_attributes ~category =
+    match SourceView.get_mark_attributes obj category with
+    | Some obj -> Some (new source_mark_attributes obj)
+    | None -> None
+
+  method get_mark_priority ~category = SourceView.get_mark_priority obj category
+
+end
+
+let source_view ?source_buffer ?draw_spaces =
+  SourceView.make_params [] ~cont:(
+    GtkText.View.make_params ~cont:(
+      GContainer.pack_container ~create:(fun pl ->
+        let obj =
+          match source_buffer with
+          | Some buf ->
+              SourceView.new_with_buffer
+                (Gobject.try_cast buf#as_buffer "GtkSourceBuffer")
+          | None -> SourceView.new_ ()
+        in
+        Gobject.set_params (Gobject.try_cast obj "GtkSourceView") pl;
+	(* may (SourceView.set_draw_spaces obj) draw_spaces; *)
+        new source_view obj)))
+
+(** {2 Misc} *)
+
+(*
+let iter_forward_search (iter:GText.iter) flags
+    ~start ~stop ?limit str =
+  let limit = map_opt (fun x -> x#as_iter) limit in
+  match SourceViewMisc.iter_forward_search iter#as_iter str
+      flags ~start: start#as_iter ~stop: stop#as_iter limit
+  with
+    None -> None
+  | Some (it1,it2) -> Some (new GText.iter it1, new GText.iter it2)
+
+let iter_backward_search (iter:GText.iter) flags
+    ~start ~stop ?limit str =
+  let limit = map_opt (fun x -> x#as_iter) limit in
+  match SourceViewMisc.iter_backward_search iter#as_iter str
+      flags ~start: start#as_iter ~stop: stop#as_iter limit
+  with
+    None -> None
+  | Some (it1,it2) -> Some (new GText.iter it1, new GText.iter it2)
+*)

--- a/src-sourceview4/gSourceView4.mli
+++ b/src-sourceview4/gSourceView4.mli
@@ -1,0 +1,571 @@
+(**************************************************************************)
+(*                Lablgtk                                                 *)
+(*                                                                        *)
+(*    This program is free software; you can redistribute it              *)
+(*    and/or modify it under the terms of the GNU Library General         *)
+(*    Public License as published by the Free Software Foundation         *)
+(*    version 2, with the exception described in file COPYING which       *)
+(*    comes with the library.                                             *)
+(*                                                                        *)
+(*    This program is distributed in the hope that it will be useful,     *)
+(*    but WITHOUT ANY WARRANTY; without even the implied warranty of      *)
+(*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the       *)
+(*    GNU Library General Public License for more details.                *)
+(*                                                                        *)
+(*    You should have received a copy of the GNU Library General          *)
+(*    Public License along with this program; if not, write to the        *)
+(*    Free Software Foundation, Inc., 59 Temple Place, Suite 330,         *)
+(*    Boston, MA 02111-1307  USA                                          *)
+(*                                                                        *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** {2 GtkSourceView interface} *)
+
+open Gtk
+open GText
+open SourceView4Enums
+
+(** {2 GtkSourceStyleScheme} *)
+
+class source_style_scheme :
+  GtkSourceView4_types.source_style_scheme obj ->
+  object
+    method as_source_style_scheme :
+      GtkSourceView4_types.source_style_scheme obj
+    method name : string
+    method description : string
+  end
+
+
+(** {2 GtkSourceStyleSchemeManager} *)
+
+class source_style_scheme_manager :
+  GtkSourceView4_types.source_style_scheme_manager obj ->
+  object
+    method search_path: string list
+    method set_search_path: string list -> unit
+    method append_search_path: string -> unit
+    method prepend_search_path: string -> unit
+    method style_scheme_ids: string list
+    method style_scheme: string -> source_style_scheme option
+    method force_rescan: unit -> unit
+  end
+
+val source_style_scheme_manager : default:bool -> source_style_scheme_manager
+
+(** {2 GtkSourceCompletionInfo} *)
+
+class source_completion_info_signals :
+  (GtkSourceView4_types.source_completion_info as 'b) obj ->
+  object ('a)
+    inherit GContainer.container_signals
+    method before_show : callback:(unit -> unit) -> GtkSignal.id
+    method notify_max_height : callback:(int -> unit) -> GtkSignal.id
+    method notify_max_width : callback:(int -> unit) -> GtkSignal.id
+    method notify_shrink_height : callback:(bool -> unit) -> GtkSignal.id
+    method notify_shrink_width : callback:(bool -> unit) -> GtkSignal.id
+  end
+
+class source_completion_info :
+  ([> GtkSourceView4_types.source_completion_info ] as 'a) obj ->
+  object
+    inherit GWindow.window
+    val obj : 'a obj
+    method as_source_completion_info : GtkSourceView4_types.source_completion_info obj
+    method max_height : int
+    method max_width : int
+(*    method process_resize : unit -> unit*)
+    method set_max_height : int -> unit
+    method set_max_width : int -> unit
+    method set_shrink_height : bool -> unit
+    method set_shrink_width : bool -> unit
+(*
+    method set_sizing :
+      width:int ->
+      height:int -> shrink_width:bool -> shrink_height:bool -> unit
+*)
+    (* method set_widget : GObj.widget -> unit *)
+    method shrink_height : bool
+    method shrink_width : bool
+    (* method widget : GObj.widget *)
+  end
+
+(** {2 GtkSourceCompletionProposal} *)
+
+class source_completion_proposal_signals :
+  GtkSourceView4_types.source_completion_proposal obj ->
+  object ('a)
+    method after : 'a
+    method changed : callback:(unit -> unit) -> GtkSignal.id
+    method notify_icon : callback:(GdkPixbuf.pixbuf -> unit) -> GtkSignal.id
+    method notify_info : callback:(string -> unit) -> GtkSignal.id
+    method notify_label : callback:(string -> unit) -> GtkSignal.id
+    method notify_markup : callback:(string -> unit) -> GtkSignal.id
+    method notify_text : callback:(string -> unit) -> GtkSignal.id
+  end
+
+class source_completion_proposal :
+  GtkSourceView4_types.source_completion_proposal obj ->
+  object
+    method as_source_completion_proposal : GtkSourceView4_types.source_completion_proposal obj
+    method connect : source_completion_proposal_signals
+    method icon : GdkPixbuf.pixbuf
+    method info : string
+    method label : string
+    method markup : string
+    method text : string
+  end
+
+class source_completion_item :
+  GtkSourceView4_types.source_completion_proposal obj ->
+  object
+    inherit source_completion_proposal
+    method set_icon : GdkPixbuf.pixbuf -> unit
+    method set_info : string -> unit
+    method set_label : string -> unit
+    method set_markup : string -> unit
+    method set_text : string -> unit
+  end
+
+val source_completion_item :
+  ?label:string ->
+  ?text:string ->
+  ?icon:GdkPixbuf.pixbuf ->
+  ?info:string -> unit -> source_completion_item
+
+(* val source_completion_item_with_markup :
+ *   ?label:string ->
+ *   ?text:string ->
+ *   ?icon:GdkPixbuf.pixbuf ->
+ *   ?info:string -> unit -> source_completion_item *)
+
+(* val source_completion_item_from_stock :
+ *   ?label:string ->
+ *   ?text:string ->
+ *   stock:GtkStock.id -> info:string -> unit -> source_completion_item *)
+
+(** {2 GtkSourceCompletionProvider} *)
+
+class source_completion_provider :
+  GtkSourceView4_types.source_completion_provider obj ->
+  object
+    method as_source_completion_provider : GtkSourceView4_types.source_completion_provider obj
+    method icon : GdkPixbuf.pixbuf option
+    method name : string
+    method populate : source_completion_context -> unit
+    method activation : source_completion_activation_flags list
+    method matched : source_completion_context -> bool
+    method info_widget : source_completion_proposal -> GObj.widget option
+    method update_info : source_completion_proposal -> source_completion_info -> unit
+    method start_iter : source_completion_context -> source_completion_proposal -> GText.iter
+    method activate_proposal : source_completion_proposal -> GText.iter -> bool
+    method interactive_delay : int
+    method priority : int
+  end
+
+(** {2 GtkSourceCompletionContext} *)
+
+and source_completion_context_signals :
+  GtkSourceView4_types.source_completion_context obj ->
+  object ('a)
+    method after : 'a
+    method cancelled : callback:(unit -> unit) -> GtkSignal.id
+  end
+
+and source_completion_context :
+  GtkSourceView4_types.source_completion_context obj ->
+  object
+    method as_source_completion_context : GtkSourceView4_types.source_completion_context obj
+    method activation : source_completion_activation_flags list
+    method add_proposals :
+      source_completion_provider ->
+      source_completion_proposal list -> bool -> unit
+    method connect : source_completion_context_signals
+    method iter : GText.iter
+    method set_iter : GText.iter -> unit
+    method set_activation : source_completion_activation_flags list -> unit
+  end
+
+class type custom_completion_provider =
+  object
+    method name : string
+    method icon : GdkPixbuf.pixbuf option
+    method populate : source_completion_context -> unit
+    method matched : source_completion_context -> bool
+    method activation : source_completion_activation_flags list
+    method info_widget : source_completion_proposal -> GObj.widget option
+    method update_info : source_completion_proposal -> source_completion_info -> unit
+    method start_iter : source_completion_context -> source_completion_proposal -> GText.iter -> bool
+    method activate_proposal : source_completion_proposal -> GText.iter -> bool
+    method interactive_delay : int
+    method priority : int
+  end
+
+val source_completion_provider : custom_completion_provider -> source_completion_provider
+
+(** {2 GtkSourceCompletion} *)
+
+class source_completion_signals :
+  GtkSourceView4_types.source_completion obj ->
+  object ('a)
+    method after : 'a
+    method activate_proposal : callback:(unit -> unit) -> GtkSignal.id
+    method hide : callback:(unit -> unit) -> GtkSignal.id
+    method move_cursor :
+      callback:(GtkEnums.scroll_step -> int -> unit) -> GtkSignal.id
+    method move_page :
+      callback:(GtkEnums.scroll_step -> int -> unit) -> GtkSignal.id
+    method populate_context :
+      callback:(source_completion_context -> unit) -> GtkSignal.id
+    method show : callback:(unit -> unit) -> GtkSignal.id
+    method notify_accelerators : callback:(int -> unit) -> GtkSignal.id
+    method notify_auto_complete_delay : callback:(int -> unit) -> GtkSignal.id
+    method notify_proposal_page_size : callback:(int -> unit) -> GtkSignal.id
+    method notify_provider_page_size : callback:(int -> unit) -> GtkSignal.id
+    method notify_remember_info_visibility :
+      callback:(bool -> unit) -> GtkSignal.id
+    method notify_select_on_show : callback:(bool -> unit) -> GtkSignal.id
+    method notify_show_headers : callback:(bool -> unit) -> GtkSignal.id
+    method notify_show_icons : callback:(bool -> unit) -> GtkSignal.id
+  end
+
+class source_completion :
+  GtkSourceView4_types.source_completion obj ->
+  object
+    method accelerators : int
+    method add_provider : source_completion_provider -> bool
+    method as_source_completion : GtkSourceView4_types.source_completion obj
+    method auto_complete_delay : int
+    method block_interactive : unit -> unit
+    method connect : source_completion_signals
+    method create_context : GText.iter -> source_completion_context
+    method hide : unit -> unit
+    (* method move_window : GText.iter -> unit *)
+    method proposal_page_size : int
+    method providers : source_completion_provider list
+    method provider_page_size : int
+    method remember_info_visibility : bool
+    method remove_provider : source_completion_provider -> bool
+    method select_on_show : bool
+    method set_accelerators : int -> unit
+    method set_auto_complete_delay : int -> unit
+    method set_proposal_page_size : int -> unit
+    method set_provider_page_size : int -> unit
+    method set_remember_info_visibility : bool -> unit
+    method set_select_on_show : bool -> unit
+    method set_show_headers : bool -> unit
+    method set_show_icons : bool -> unit
+    (* method show : source_completion_provider list -> source_completion_context -> bool *)
+    method show_headers : bool
+    method show_icons : bool
+    method unblock_interactive : unit -> unit
+  end
+
+(** {2 GtkSourceLanguage} *)
+
+class source_language:
+  GtkSourceView4_types.source_language obj ->
+  object
+    method as_source_language: GtkSourceView4_types.source_language obj
+    method misc: GObj.gobject_ops
+
+    method hidden: bool
+    method id: string
+    method name: string
+    method section: string
+
+    method metadata: string -> string option
+    method mime_types: string list
+    method globs: string list
+    method style_name: string -> string option
+    method style_ids: string list
+  end
+
+(** {2 GtkSourceLanguageManager} *)
+
+class source_language_manager:
+  GtkSourceView4_types.source_language_manager obj ->
+  object
+    method get_oid: int
+    method as_source_language_manager:
+      GtkSourceView4_types.source_language_manager obj
+
+    method set_search_path : string list -> unit
+    method search_path : string list
+    method language_ids : string list
+    method language : string -> source_language option
+    method guess_language:
+      ?filename:string -> ?content_type:string -> unit -> source_language option
+  end
+
+val source_language_manager : default:bool -> source_language_manager
+
+
+(** {2 GtkSourceMark} *)
+
+class source_mark: ((GtkSourceView4_types.source_mark obj) as 'a) ->
+object
+  method as_source_mark : 'a
+  method coerce: GText.mark
+  method category: string option
+  method next: ?category:string -> unit -> source_mark option
+  method prev: ?category:string -> unit -> source_mark option
+end
+
+val source_mark : ?category:string -> unit -> source_mark
+
+(** {2 GtkSourceMarkAttributes} *)
+class source_mark_attributes:
+  ((GtkSourceView4_types.source_mark_attributes obj) as 'a) ->
+  object
+    method as_source_mark_attributes: 'a
+    method set_background: Gdk.rgba -> unit
+    method set_icon_name: string -> unit
+    method set_pixbuf: GdkPixbuf.pixbuf -> unit
+    method background: Gdk.rgba
+    method icon_name: string
+    method pixbuf: GdkPixbuf.pixbuf
+  end
+
+val source_mark_attributes: unit -> source_mark_attributes
+
+(** {2 GtkSourceUndoManager} *)
+
+class source_undo_manager_signals :
+  (GtkSourceView4_types.source_undo_manager as 'b) obj ->
+object ('a)
+  method after : 'a
+  method can_redo_changed : callback:(unit -> unit) -> GtkSignal.id
+  method can_undo_changed : callback:(unit -> unit) -> GtkSignal.id
+end
+
+class source_undo_manager: (GtkSourceView4_types.source_undo_manager as 'b) obj ->
+  object
+    val obj : 'b obj
+    method as_source_undo_manager : GtkSourceView4_types.source_undo_manager obj
+    method begin_not_undoable_action : unit -> unit
+    method connect : source_undo_manager_signals
+    method can_redo : bool
+    method can_redo_changed : unit -> unit
+    method can_undo : bool
+    method can_undo_changed : unit -> unit
+    method end_not_undoable_action : unit -> unit
+    method redo : unit -> unit
+    method undo : unit -> unit
+  end
+
+class type custom_undo_manager =
+  object
+    method can_undo : bool
+    method can_redo : bool
+    method undo : unit -> unit
+    method redo : unit -> unit
+    method begin_not_undoable_action : unit -> unit
+    method end_not_undoable_action : unit -> unit
+    method can_undo_changed : unit -> unit
+    method can_redo_changed : unit -> unit
+  end
+
+val source_undo_manager : custom_undo_manager -> source_undo_manager
+
+(** {2 GtkSourceBuffer} *)
+
+class source_buffer_signals:
+  (GtkSourceView4_types.source_buffer as 'b) obj ->
+object ('a)
+  inherit ['b] GText.buffer_signals_type
+  method changed : callback:(unit -> unit) -> GtkSignal.id
+  method highlight_updated:
+    callback:(Gtk.text_iter -> Gtk.text_iter -> unit) -> GtkSignal.id
+  method source_mark_updated: callback:(GtkSourceView4_types.source_mark obj -> unit) -> GtkSignal.id
+  method notify_can_redo : callback:(bool -> unit) -> GtkSignal.id
+  method notify_can_undo : callback:(bool -> unit) -> GtkSignal.id
+  method notify_highlight_matching_brackets : callback:(bool -> unit) -> GtkSignal.id
+  method notify_highlight_syntax : callback:(bool -> unit) -> GtkSignal.id
+  method notify_max_undo_levels : callback:(int -> unit) -> GtkSignal.id
+end
+
+and source_buffer: GtkSourceView4_types.source_buffer obj ->
+object
+  inherit GText.buffer_skel
+  val obj: GtkSourceView4_types.source_buffer obj
+  method as_source_buffer: GtkSourceView4_types.source_buffer obj
+  method connect: source_buffer_signals
+  method misc: GObj.gobject_ops
+
+  method highlight_syntax: bool
+  method set_highlight_syntax: bool -> unit
+  method language: source_language option
+  method set_language: source_language option -> unit
+  method highlight_matching_brackets: bool
+  method set_highlight_matching_brackets: bool -> unit
+  method style_scheme: source_style_scheme option
+  method set_style_scheme: source_style_scheme option -> unit
+  method max_undo_levels: int
+  method set_max_undo_levels: int -> unit
+  method undo: unit -> unit
+  method redo: unit -> unit
+  method can_undo: bool
+  method can_redo: bool
+  method begin_not_undoable_action: unit -> unit
+  method end_not_undoable_action: unit -> unit
+
+  method create_source_mark: ?name:string -> ?category:string -> GText.iter
+    -> source_mark
+  method source_marks_at_line: ?category:string -> int
+    -> source_mark list
+  method source_marks_at_iter: ?category:string -> GText.iter
+    -> source_mark list
+  method remove_source_marks :
+    ?category:string -> start:GText.iter -> stop:GText.iter -> unit -> unit
+
+  method forward_iter_to_source_mark: ?category:string -> GText.iter -> bool
+  method backward_iter_to_source_mark: ?category:string -> GText.iter -> bool
+
+  method iter_has_context_class: GText.iter -> string -> bool
+  method iter_forward_to_context_class_toggle: GText.iter -> string -> bool
+  method iter_backward_to_context_class_toggle: GText.iter -> string -> bool
+
+  method ensure_highlight: start:GText.iter -> stop:GText.iter -> unit
+
+  method undo_manager : source_undo_manager
+
+  method set_undo_manager : source_undo_manager -> unit
+
+end
+
+val source_buffer:
+  ?language:source_language ->
+  ?style_scheme:source_style_scheme ->
+  ?tag_table:GText.tag_table ->
+  ?text:string ->
+  ?undo_manager:source_undo_manager ->
+  ?highlight_matching_brackets:bool ->
+  ?highlight_syntax:bool ->
+  ?max_undo_levels:int ->
+  unit -> source_buffer
+
+(** {2 GtkSourceView} *)
+
+class source_view_signals:
+  ([> GtkSourceView4_types.source_view ] as 'b) obj ->
+  object ('a)
+    inherit GText.view_signals
+    method line_mark_activated :
+      callback:(Gtk.text_iter -> GdkEvent.any -> unit) -> GtkSignal.id
+    method move_lines : callback:(bool -> int -> unit) -> GtkSignal.id
+    method move_words : callback:(int -> unit) -> GtkSignal.id
+    method redo: callback:(unit -> unit) -> GtkSignal.id
+    method show_completion : callback:(unit -> unit) -> GtkSignal.id
+    method smart_home_end :
+      callback:(Gtk.text_iter -> int -> unit) -> GtkSignal.id
+    method undo: callback:(unit -> unit) -> GtkSignal.id
+    method notify_auto_indent : callback:(bool -> unit) -> GtkSignal.id
+    method notify_highlight_current_line : callback:(bool -> unit) -> GtkSignal.id
+    method notify_indent_on_tab : callback:(bool -> unit) -> GtkSignal.id
+    method notify_indent_width : callback:(int -> unit) -> GtkSignal.id
+    method notify_insert_spaces_instead_of_tabs : callback:(bool -> unit) -> GtkSignal.id
+    method notify_right_margin_position : callback:(int -> unit) -> GtkSignal.id
+    method notify_show_line_marks : callback:(bool -> unit) -> GtkSignal.id
+    method notify_show_line_numbers : callback:(bool -> unit) -> GtkSignal.id
+    method notify_show_right_margin : callback:(bool -> unit) -> GtkSignal.id
+    (* method notify_smart_home_end :
+     *   callback:(SourceView4Enums.source_smart_home_end_type -> unit) -> GtkSignal.id *)
+    method notify_tab_width : callback:(int -> unit) -> GtkSignal.id
+
+  end
+
+class source_view:
+  GtkSourceView4_types.source_view obj ->
+object
+  inherit GText.view_skel
+  inherit OgtkSourceView4Props.source_view_props
+  val obj: GtkSourceView4_types.source_view obj
+  method completion : source_completion
+  method connect: source_view_signals
+  method source_buffer: source_buffer
+  method set_show_line_numbers: bool -> unit
+  method show_line_numbers: bool
+  method set_highlight_current_line: bool -> unit
+  method highlight_current_line: bool
+  method set_tab_width: int -> unit
+  method tab_width: int
+  method set_auto_indent: bool -> unit
+  method auto_indent: bool
+  method set_insert_spaces_instead_of_tabs: bool -> unit
+  method insert_spaces_instead_of_tabs: bool
+  method set_cursor_color: Gdk.color -> unit
+(*  method set_cursor_color_by_name: string -> unit*)
+
+  (* method draw_spaces: source_draw_spaces_flags list
+   * method set_draw_spaces: source_draw_spaces_flags list -> unit *)
+
+  method set_mark_attributes:
+    category:string -> source_mark_attributes -> int -> unit
+
+  method get_mark_attributes:
+    category:string -> source_mark_attributes option
+
+  method get_mark_priority: category:string -> int
+
+(*
+  method get_mark_category_priority:
+    category:string -> int
+  method set_mark_category_priority:
+    category:string -> int -> unit
+  method get_mark_category_pixbuf:
+    category:string -> GdkPixbuf.pixbuf option
+  method set_mark_category_pixbuf:
+    category:string -> GdkPixbuf.pixbuf option -> unit
+  method get_mark_category_background:
+    category:string -> Gdk.color option
+  method set_mark_category_background:
+    category:string -> Gdk.color option -> unit
+*)
+end
+
+val source_view :
+  ?source_buffer:source_buffer ->
+  ?draw_spaces:int list ->
+  ?auto_indent:bool ->
+  ?highlight_current_line:bool ->
+  ?indent_on_tab:bool ->
+  ?indent_width:int ->
+  ?insert_spaces_instead_of_tabs:bool ->
+  ?right_margin_position:int ->
+  ?show_line_marks:bool ->
+  ?show_line_numbers:bool ->
+  ?show_right_margin:bool ->
+  (* ?smart_home_end:source_smart_home_end_type -> *)
+  ?tab_width:int ->
+  ?editable:bool ->
+  ?cursor_visible:bool ->
+  ?justification:GtkEnums.justification ->
+  ?wrap_mode:GtkEnums.wrap_mode ->
+  ?accepts_tab:bool ->
+  ?border_width:int ->
+  ?width:int ->
+  ?height:int ->
+  ?packing:(GObj.widget -> unit) -> ?show:bool -> unit -> source_view
+
+
+(** {2 Misc} *)
+
+(*
+val iter_forward_search :
+  GText.iter ->
+  source_search_flag list ->
+  start:< as_iter : Gtk.text_iter; .. > ->
+  stop:< as_iter : Gtk.text_iter; .. > ->
+  ?limit:< as_iter : Gtk.text_iter; .. > ->
+  string -> (GText.iter * GText.iter) option
+
+val iter_backward_search :
+  GText.iter ->
+  source_search_flag list ->
+  start:< as_iter : Gtk.text_iter; .. > ->
+  stop:< as_iter : Gtk.text_iter; .. > ->
+  ?limit:< as_iter : Gtk.text_iter; .. > ->
+  string -> (GText.iter * GText.iter) option
+*)

--- a/src-sourceview4/gtkSourceView4.ml
+++ b/src-sourceview4/gtkSourceView4.ml
@@ -1,0 +1,283 @@
+(**************************************************************************)
+(*                Lablgtk                                                 *)
+(*                                                                        *)
+(*    This program is free software; you can redistribute it              *)
+(*    and/or modify it under the terms of the GNU Library General         *)
+(*    Public License as published by the Free Software Foundation         *)
+(*    version 2, with the exception described in file COPYING which       *)
+(*    comes with the library.                                             *)
+(*                                                                        *)
+(*    This program is distributed in the hope that it will be useful,     *)
+(*    but WITHOUT ANY WARRANTY; without even the implied warranty of      *)
+(*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the       *)
+(*    GNU Library General Public License for more details.                *)
+(*                                                                        *)
+(*    You should have received a copy of the GNU Library General          *)
+(*    Public License along with this program; if not, write to the        *)
+(*    Free Software Foundation, Inc., 59 Temple Place, Suite 330,         *)
+(*    Boston, MA 02111-1307  USA                                          *)
+(*                                                                        *)
+(*                                                                        *)
+(**************************************************************************)
+
+open GtkSourceView4_types
+open Gaux
+open Gobject
+open Gtk
+open Tags
+open SourceView4Enums
+open GtkSourceView4Props
+open GtkBase
+
+module SourceStyleScheme =
+struct
+  include SourceStyleScheme
+  external get_name: source_style_scheme obj -> string =
+    "ml_gtk_source_style_scheme_get_name"
+  external get_description: source_style_scheme obj -> string =
+    "ml_gtk_source_style_scheme_get_description"
+end
+
+module SourceCompletionItem =
+struct
+  include SourceCompletionItem
+
+  external new_:
+    string -> string -> GdkPixbuf.pixbuf option -> string option -> source_completion_proposal obj =
+    "ml_gtk_source_completion_item_new"
+
+  (* external new_with_markup:
+   *   string -> string -> GdkPixbuf.pixbuf option -> string option -> source_completion_proposal obj =
+   *   "ml_gtk_source_completion_item_new_with_markup" *)
+  (* external new_from_stock:
+   *   string -> string -> string -> string -> source_completion_proposal obj =
+   *   "ml_gtk_source_completion_item_new_from_stock"  *)
+
+end
+
+module SourceCompletionProvider =
+struct
+  include SourceCompletionProvider
+
+  type provider = {
+    provider_name : unit -> string;
+    provider_icon : unit -> GdkPixbuf.pixbuf option;
+    provider_populate : source_completion_context obj -> unit;
+    provider_activation : unit -> source_completion_activation_flags list;
+    provider_match : source_completion_context obj -> bool;
+    provider_info_widget : source_completion_proposal obj -> widget obj option;
+    provider_update_info : source_completion_proposal obj -> source_completion_info obj -> unit;
+    provider_start_iter : source_completion_context obj -> source_completion_proposal obj -> text_iter -> bool;
+    provider_activate_proposal : source_completion_proposal obj -> text_iter -> bool;
+    provider_interactive_delay : unit -> int;
+    provider_priority : unit -> int;
+  }
+
+  external match_ : source_completion_provider obj -> source_completion_context obj -> bool =
+    "ml_gtk_source_completion_provider_match"
+  external new_ : provider -> source_completion_provider obj =
+    "ml_custom_completion_provider_new"
+
+end
+
+module SourceCompletionContext = SourceCompletionContext
+
+module SourceCompletionInfo = SourceCompletionInfo
+
+module SourceCompletion = SourceCompletion
+
+module SourceStyleSchemeManager =
+struct
+  include SourceStyleSchemeManager
+
+  external new_ : unit -> source_style_scheme_manager obj =
+    "ml_gtk_source_style_scheme_manager_new"
+  external default : unit -> source_style_scheme_manager obj =
+    "ml_gtk_source_style_scheme_manager_get_default"
+end
+
+module SourceLanguage =
+struct
+  include SourceLanguage
+
+  external get_id : [>`sourcelanguage] obj -> string
+    = "ml_gtk_source_language_get_id"
+  external get_name : [>`sourcelanguage] obj -> string
+    = "ml_gtk_source_language_get_name"
+  external get_section : [>`sourcelanguage] obj -> string
+    = "ml_gtk_source_language_get_section"
+  external get_hidden : [>`sourcelanguage] obj -> bool
+    = "ml_gtk_source_language_get_hidden"
+
+  external metadata: [>`sourcelanguage] obj -> string -> string option=
+    "ml_gtk_source_language_get_metadata"
+  external mime_types: [>`sourcelanguage] obj -> string list =
+    "ml_gtk_source_language_get_mime_types"
+  external globs: [>`sourcelanguage] obj -> string list =
+    "ml_gtk_source_language_get_globs"
+  external style_name: [>`sourcelanguage] obj -> string -> string option =
+    "ml_gtk_source_language_get_style_name"
+  external style_ids: [>`sourcelanguage] obj -> string list =
+    "ml_gtk_source_language_get_style_ids"
+end
+
+module SourceLanguageManager =
+struct
+  include SourceLanguageManager
+  external new_: unit -> source_language_manager obj =
+    "ml_gtk_source_language_manager_new"
+
+  external default: unit -> source_language_manager obj
+    = "ml_gtk_source_language_manager_get_default"
+
+  external set_search_path:
+    [>`sourcelanguagemanager] obj -> string list -> unit
+    = "ml_gtk_source_language_manager_set_search_path"
+
+  external search_path:
+    [>`sourcelanguagemanager] obj -> string list
+    = "ml_gtk_source_language_manager_get_search_path"
+
+  external language_ids:
+    [>`sourcelanguagemanager] obj -> string list
+    = "ml_gtk_source_language_manager_get_language_ids"
+
+  external language:
+    [>`sourcelanguagemanager] obj -> string -> source_language obj option
+    = "ml_gtk_source_language_manager_get_language"
+
+  external guess_language:
+    [>`sourcelanguagemanager] obj ->
+    string option -> string option -> source_language obj option
+    = "ml_gtk_source_language_manager_guess_language"
+
+end
+
+module SourceUndoManager =
+struct
+  include SourceUndoManager
+
+  type undo_manager = {
+    can_undo : unit -> bool;
+    can_redo : unit -> bool;
+    undo : unit -> unit;
+    redo : unit -> unit;
+    begin_not_undoable_action : unit -> unit;
+    end_not_undoable_action : unit -> unit;
+    can_undo_changed : unit -> unit;
+    can_redo_changed : unit -> unit;
+  }
+
+  external new_ : undo_manager -> [`sourceundomanager] obj =
+    "ml_custom_undo_manager_new"
+
+end
+
+module SourceBuffer =
+struct
+  include SourceBuffer
+   external new_: [`texttagtable] obj -> source_buffer obj = "ml_gtk_source_buffer_new"
+   external new_with_langage: [>`sourcelanguage] obj -> source_buffer obj =
+    "ml_gtk_source_buffer_new_with_language"
+  external undo: [>`sourcebuffer] obj -> unit = "ml_gtk_source_buffer_undo"
+  external redo: [>`sourcebuffer] obj -> unit = "ml_gtk_source_buffer_redo"
+  external begin_not_undoable_action: [>`sourcebuffer] obj -> unit =
+    "ml_gtk_source_buffer_begin_not_undoable_action"
+  external end_not_undoable_action: [>`sourcebuffer] obj -> unit =
+    "ml_gtk_source_buffer_end_not_undoable_action"
+  external set_highlight_matching_brackets: [>`sourcebuffer] obj -> bool -> unit =
+    "ml_gtk_source_buffer_set_highlight_matching_brackets"
+  external create_source_mark:
+      [>`sourcebuffer] obj -> string option -> string option -> Gtk.text_iter ->
+      source_mark obj =
+      "ml_gtk_source_buffer_create_source_mark"
+  external remove_source_marks:
+      [>`sourcebuffer] obj
+    -> Gtk.text_iter -> Gtk.text_iter -> string option -> unit =
+    "ml_gtk_source_buffer_remove_source_marks"
+  external get_source_marks_at_line:
+      [>`sourcebuffer] obj -> int -> string option -> source_mark obj list =
+      "ml_gtk_source_buffer_get_source_marks_at_line"
+  external get_source_marks_at_iter:
+    [>`sourcebuffer] obj -> Gtk.text_iter -> string option ->
+    source_mark obj list =
+    "ml_gtk_source_buffer_get_source_marks_at_iter"
+  external forward_iter_to_source_mark:
+    [>`sourcebuffer] obj -> Gtk.text_iter -> string option -> bool =
+    "ml_gtk_source_buffer_forward_iter_to_source_mark"
+  external backward_iter_to_source_mark:
+    [>`sourcebuffer] obj -> Gtk.text_iter -> string option -> bool =
+    "ml_gtk_source_buffer_backward_iter_to_source_mark"
+
+  external iter_has_context_class:
+    [>`sourcebuffer] obj -> Gtk.text_iter -> string -> bool =
+    "ml_gtk_source_buffer_iter_has_context_class"
+  external iter_forward_to_context_class_toggle:
+    [>`sourcebuffer] obj -> Gtk.text_iter -> string -> bool =
+    "ml_gtk_source_buffer_iter_forward_to_context_class_toggle"
+  external iter_backward_to_context_class_toggle:
+    [>`sourcebuffer] obj -> Gtk.text_iter -> string -> bool =
+    "ml_gtk_source_buffer_iter_backward_to_context_class_toggle"
+
+
+  external ensure_highlight:
+    [>`sourcebuffer] obj -> Gtk.text_iter -> Gtk.text_iter -> unit =
+    "ml_gtk_source_buffer_ensure_highlight"
+end
+
+module SourceView =
+struct
+  include SourceView
+  external new_: unit -> source_view obj = "ml_gtk_source_view_new"
+  external new_with_buffer: [>`sourcebuffer] obj -> source_view obj =
+    "ml_gtk_source_view_new_with_buffer"
+(*
+  external set_mark_category_pixbuf:  [>`sourceview] obj -> string -> GdkPixbuf.pixbuf option -> unit =
+    "ml_gtk_source_view_set_mark_category_pixbuf"
+  external get_mark_category_pixbuf:  [>`sourceview] obj -> string -> GdkPixbuf.pixbuf option =
+    "ml_gtk_source_view_get_mark_category_pixbuf"
+*)
+
+  external get_mark_attributes:
+    [>`sourceview] obj -> category:string -> source_mark_attributes obj option =
+    "ml_gtk_source_view_get_mark_attributes"
+
+  external get_mark_priority: [>`sourceview] obj -> category:string -> int =
+    "ml_gtk_source_view_get_mark_priority"
+
+  (* Should probably not exist *)
+  external set_cursor_color:   [>`sourceview] obj -> Gdk.color -> unit =
+    "ml_gtk_modify_cursor_color"
+end
+
+module SourceMark =
+struct
+  include SourceMark
+  external next: [> `sourcemark] obj -> string option -> source_mark obj option
+    = "ml_gtk_source_mark_next"
+  external prev: [> `sourcemark] obj -> string option -> source_mark obj option
+    = "ml_gtk_source_mark_prev"
+end
+
+module SourceMarkAttributes =
+struct
+  include SourceMarkAttributes
+  external new_attribute: unit -> source_mark_attributes obj =
+    "ml_gtk_source_mark_attributes_new"
+end
+
+module SourceViewMisc =
+struct
+(*
+  external iter_backward_search:
+       Gtk.text_iter -> string -> SourceView2Enums.source_search_flag list ->
+	start: Gtk.text_iter -> stop: Gtk.text_iter -> Gtk.text_iter option ->
+	(Gtk.text_iter * Gtk.text_iter) option =
+    "ml_gtk_source_iter_backward_search_bc" "ml_gtk_source_iter_backward_search"
+  external iter_forward_search:
+      Gtk.text_iter -> string -> SourceView2Enums.source_search_flag list ->
+	start: Gtk.text_iter -> stop: Gtk.text_iter -> Gtk.text_iter option ->
+	(Gtk.text_iter * Gtk.text_iter) option =
+    "ml_gtk_source_iter_forward_search_bc" "ml_gtk_source_iter_forward_search"
+*)
+end

--- a/src-sourceview4/gtkSourceView4.props
+++ b/src-sourceview4/gtkSourceView4.props
@@ -1,0 +1,250 @@
+(*********************************************************************************)
+(*                                                                               *)
+(*   lablgtksourceview, OCaml binding for the GtkSourceView text widget          *)
+(*                                                                               *)
+(*   Copyright (C) 2005  Stefano Zacchiroli <zack@cs.unibo.it>                   *)
+(*   Copyright (C) 2006  Stefano Zacchiroli <zack@cs.unibo.it>                   *)
+(*                       Maxence Guesdon <maxence.guesdon@inria.fr>              *)
+(*                                                                               *)
+(*   This library is free software; you can redistribute it and/or modify        *)
+(*   it under the terms of the GNU Lesser General Public License as              *)
+(*   published by the Free Software Foundation; either version 2.1 of the        *)
+(*   License, or (at your option) any later version.                             *)
+(*                                                                               *)
+(*   This library is distributed in the hope that it will be useful, but         *)
+(*   WITHOUT ANY WARRANTY; without even the implied warranty of                  *)
+(*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU           *)
+(*   Lesser General Public License for more details.                             *)
+(*                                                                               *)
+(*   You should have received a copy of the GNU Lesser General Public            *)
+(*   License along with this library; if not, write to the Free Software         *)
+(*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307         *)
+(*   USA                                                                         *)
+(*                                                                               *)
+(*********************************************************************************)
+
+prefix "Gtk"
+initializer "ml_gtk_source_view_init"
+
+header {
+  open GtkSourceView4_types
+  open SourceView4Enums
+}
+
+boxed {
+  GdkEvent    "GdkEvent.any"
+  GdkRGBA     "Gdk.rgba"
+}
+
+classes {
+  GdkPixbuf "GdkPixbuf.pixbuf"
+}
+
+class SourceStyleScheme type "source_style_scheme obj" set wrapsig : GObject {
+}
+
+class SourceStyleSchemeManager type "source_style_scheme_manager obj" wrap : GObject {
+(*  "scheme-ids"          GStrv                 : Read *)
+(*  "search-path"         GStrv                 : Read / Write *)
+
+  method get_search_path : "string list"
+  method set_search_path : "string list -> unit"
+  method get_scheme_ids : "string list"
+
+  method append_search_path : "string -> unit" / Wrap
+  method prepend_search_path : "string -> unit" / Wrap
+  method get_scheme : "string -> source_style_scheme obj option"
+  method force_rescan : "unit -> unit" / Wrap
+}
+
+class SourceCompletionInfo type "source_completion_info obj" wrap wrapsig : GtkWidget {
+  "max-height"               gint                  : Read / Write / Construct
+  "max-width"                gint                  : Read / Write / Construct
+  "shrink-height"            gboolean              : Read / Write / Construct
+  "shrink-width"             gboolean              : Read / Write / Construct
+
+  method move_to_iter : "Gtk.text_view obj -> Gtk.text_iter -> unit"
+(*
+  method set_sizing :
+    "width:int -> height:int -> shrink_width:bool -> shrink_height:bool -> unit" / Wrap
+*)
+(*  method set_widget : "Gtk.widget obj -> unit" *)
+(*  method get_widget : "Gtk.widget obj" *)
+(*  method process_resize : "unit" / Wrap*)
+
+  signal before_show
+}
+
+class SourceCompletionProposal type "source_completion_proposal obj" wrap wrapsig : GObject {
+  "icon"                     GdkPixbuf           : Read
+  "info"                     string               : Read
+  "label"                    string              : Read
+  "markup"                   string                : Read
+  "text"                     string               : Read
+
+  signal changed
+}
+
+class SourceCompletionItem type "source_completion_proposal obj" tag "sourcecompletionproposal" wrap wrapsig : GObject {
+  "icon"                     GdkPixbuf           : Read / Write
+  "info"                     string               : Read / Write
+  "label"                    string              : Read / Write
+  "markup"                   string                : Read / Write
+  "text"                     string               : Read / Write
+
+  signal changed
+}
+
+class SourceCompletionProvider type "source_completion_provider obj" abstract wrap wrapsig : GObject {
+  method get_name : "string"
+  method get_icon : "GdkPixbuf.pixbuf option"
+  method populate : "source_completion_context obj -> unit"
+  method get_activation : "source_completion_activation_flags list"
+  (* method match : "source_completion_context obj -> bool" *)
+  method get_info_widget : "source_completion_proposal obj -> Gtk.widget obj option"
+  method update_info : "source_completion_proposal obj -> source_completion_info obj -> unit"
+  method get_start_iter : "source_completion_context obj -> source_completion_proposal obj -> Gtk.text_iter"
+  method activate_proposal : "source_completion_proposal obj -> Gtk.text_iter -> bool"
+  method get_interactive_delay : "int"
+  method get_priority : "int"
+
+}
+
+class SourceCompletionContext type "source_completion_context obj" wrap wrapsig : GObject {
+  "completion"               GtkSourceCompletion  : Read / Write / Construct Only / NoWrap
+  "iter"                     GtkTextIter          : Read / Write / NoWrap
+
+
+  method get_activation : "source_completion_activation_flags list"
+  method set_activation : "source_completion_activation_flags list -> unit" / Wrap
+  method add_proposals :  "source_completion_provider obj -> source_completion_proposal obj list -> bool -> unit"
+
+  signal cancelled
+
+}
+
+class SourceCompletion type "source_completion obj" wrap wrapsig : GObject {
+  "accelerators"             guint                 : Read / Write / Construct
+  "auto-complete-delay"      guint                 : Read / Write / Construct
+  "proposal-page-size"       guint                 : Read / Write / Construct
+  "provider-page-size"       guint                 : Read / Write / Construct
+  "remember-info-visibility" gboolean              : Read / Write / Construct
+  "select-on-show"           gboolean              : Read / Write / Construct
+  "show-headers"             gboolean              : Read / Write / Construct
+  "show-icons"               gboolean              : Read / Write / Construct
+  "view"                     GtkSourceView        : Read / Write / Construct Only / NoWrap
+
+  method add_provider : "source_completion_provider obj -> bool"
+  method remove_provider : "source_completion_provider obj -> bool"
+  method block_interactive : "unit" / Wrap
+  method get_providers : "source_completion_provider obj list"
+  method create_context : "Gtk.text_iter -> source_completion_context obj"
+  method hide : "unit" / Wrap
+(*  method move_window : "Gtk.text_iter -> unit" *)
+(*  method show : "source_completion_provider obj list -> source_completion_context obj -> bool" *)
+  method unblock_interactive : "unit" / Wrap
+
+  signal activate_proposal
+  signal hide
+  signal move_cursor: GtkScrollStep gint
+  signal move_page: GtkScrollStep gint
+  signal populate_context : GtkSourceCompletionContext / NoWrap
+  signal show
+}
+
+class SourceLanguage type "source_language obj" set wrap wrapsig : GObject {
+  (* Property access is broken in gtkSourceView 2.4.1 (see Bugzilla #564142),
+     so we use methods instead: *)
+}
+
+class SourceLanguageManager type "source_language_manager obj" set wrapsig : GObject {
+(*       "search-path"      GStrv             : Read / Write
+       "language-ids"     GStrv             : Read / Write
+*)
+}
+
+class SourceMark type "source_mark obj" set wrap wrapsig : GObject {
+ "category"                 gchararray_opt  : Read / Write / Construct Only
+}
+
+class SourceMarkAttributes type "source_mark_attributes obj" set wrap wrapsig: GObject {
+"background" GdkRGBA  : Read / Write
+(* "icon" GIcon does not seem to have been ported in lablgtk *)
+"icon-name" string : Read / Write
+"pixbuf" GdkPixbuf : Read / Write
+}
+
+class SourceUndoManager type "source_undo_manager obj" set wrap wrapsig : GObject {
+
+  method can_undo : "bool" / Wrap
+  method can_redo : "bool" / Wrap
+  method undo : "unit" / Wrap
+  method redo : "unit" / Wrap
+  method begin_not_undoable_action : "unit" / Wrap
+  method end_not_undoable_action : "unit" / Wrap
+  method can_undo_changed : "unit" / Wrap
+  method can_redo_changed : "unit" / Wrap
+
+  signal can_redo_changed
+  signal can_undo_changed
+}
+
+class SourceBuffer type "source_buffer obj" set wrap wrapsig : GObject {
+  "can-redo"     gboolean 	       	      : Read
+  "can-undo"     gboolean		      : Read
+  "highlight-matching-brackets"   gboolean    : Read / Write
+  "highlight-syntax"     gboolean             : Read / Write
+  "language"             GtkSourceLanguage_opt: Read / Write / NoWrap
+
+  "max-undo-levels"      gint                 : Read / Write
+  "style-scheme"         GtkSourceStyleScheme_opt : Read / Write / NoWrap
+  "undo-manager"             GtkSourceUndoManager  : Read / Write / Construct / NoWrap
+
+  signal highlight_updated: GtkTextIter GtkTextIter
+  signal source_mark_updated: GtkSourceMark
+}
+
+class SourceView type "source_view obj" set wrap wrapsig : Widget {
+  "auto-indent"          gboolean             : Read / Write
+  "highlight-current-line"  gboolean          : Read / Write
+  "indent-on-tab"       gboolean              : Read / Write
+  "indent-width"        gint                  : Read / Write
+  "insert-spaces-instead-of-tabs" gboolean    : Read / Write
+  "right-margin-position" guint               : Read / Write
+  "show-line-marks"      gboolean             : Read / Write
+  "show-line-numbers"    gboolean             : Read / Write
+  "show-right-margin"    gboolean             : Read / Write
+  "smart-home-end"  Gtk4SourceSmartHomeEndType : Read / Write
+  "tab-width"          guint		      : Read / Write
+
+  method get_completion : "source_completion obj"
+
+(*  method get_draw_spaces : "source_draw_spaces_flags list" *)
+(*  method set_draw_spaces : "source_draw_spaces_flags list -> unit" *)
+
+  method set_mark_attributes:
+   "category:string -> source_mark_attributes obj -> int -> unit"
+
+(*
+  method get_mark_category_priority :
+      "category:string -> int" / Wrap
+  method set_mark_category_priority:
+      "category:string -> int -> unit" / Wrap
+  method get_mark_category_pixbuf:
+      "category:string -> GdkPixbuf.pixbuf option" / Wrap
+  method set_mark_category_pixbuf:
+      "category:string -> GdkPixbuf.pixbuf option -> unit" / Wrap
+  method get_mark_category_background:
+      "category:string -> Gdk.color option" / Wrap
+  method set_mark_category_background:
+      "category:string -> Gdk.color option -> unit" / Wrap
+*)
+
+  signal line_mark_activated : GtkTextIter GdkEvent
+  signal move_lines : gboolean gint
+  signal move_words : gint
+  signal redo
+  signal show_completion
+  signal smart_home_end : GtkTextIter gint
+  signal undo
+}

--- a/src-sourceview4/gtkSourceView4_types.mli
+++ b/src-sourceview4/gtkSourceView4_types.mli
@@ -1,0 +1,58 @@
+(**************************************************************************)
+(*                Lablgtk                                                 *)
+(*                                                                        *)
+(*    This program is free software; you can redistribute it              *)
+(*    and/or modify it under the terms of the GNU Library General         *)
+(*    Public License as published by the Free Software Foundation         *)
+(*    version 2, with the exception described in file COPYING which       *)
+(*    comes with the library.                                             *)
+(*                                                                        *)
+(*    This program is distributed in the hope that it will be useful,     *)
+(*    but WITHOUT ANY WARRANTY; without even the implied warranty of      *)
+(*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the       *)
+(*    GNU Library General Public License for more details.                *)
+(*                                                                        *)
+(*    You should have received a copy of the GNU Library General          *)
+(*    Public License along with this program; if not, write to the        *)
+(*    Free Software Foundation, Inc., 59 Temple Place, Suite 330,         *)
+(*    Boston, MA 02111-1307  USA                                          *)
+(*                                                                        *)
+(*                                                                        *)
+(**************************************************************************)
+
+(*
+ * lablgtksourceview, OCaml binding for the GtkSourceView text widget
+ *
+ * Copyright (C) 2005  Stefano Zacchiroli <zack@cs.unibo.it>
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+ * USA
+ *)
+
+type source_style_scheme = [`sourcestylescheme]
+type source_style_scheme_manager = [`sourcestyleschememanager]
+type source_completion_info = [ Gtk.window | `sourcecompletioninfo ]
+type source_completion_provider = [ `sourcecompletionprovider ]
+type source_completion_proposal = [ `sourcecompletionproposal ]
+type source_completion_activation = [ `sourcecompletionactivation ]
+type source_completion_context = [ `sourcecompletioncontext ]
+type source_completion = [ `sourcecompletion ]
+type source_view = [ Gtk.text_view | `sourceview ]
+type source_mark = [ `sourcemark ]
+type source_mark_attributes = [ `sourcemarkattributes ]
+type source_buffer = [`textbuffer|`sourcebuffer]
+type source_language = [`sourcelanguage]
+type source_language_manager = [`sourcelanguagemanager]
+type source_undo_manager = [`sourceundomanager]

--- a/src-sourceview4/ml_gtksourceview4.c
+++ b/src-sourceview4/ml_gtksourceview4.c
@@ -1,0 +1,887 @@
+/**************************************************************************/
+/*                Lablgtk                                                 */
+/*                                                                        */
+/*    This program is free software; you can redistribute it              */
+/*    and/or modify it under the terms of the GNU Library General         */
+/*    Public License as published by the Free Software Foundation         */
+/*    version 2, with the exception described in file COPYING which       */
+/*    comes with the library.                                             */
+/*                                                                        */
+/*    This program is distributed in the hope that it will be useful,     */
+/*    but WITHOUT ANY WARRANTY; without even the implied warranty of      */
+/*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the       */
+/*    GNU Library General Public License for more details.                */
+/*                                                                        */
+/*    You should have received a copy of the GNU Library General          */
+/*    Public License along with this program; if not, write to the        */
+/*    Free Software Foundation, Inc., 59 Temple Place, Suite 330,         */
+/*    Boston, MA 02111-1307  USA                                          */
+/*                                                                        */
+/*                                                                        */
+/**************************************************************************/
+
+#include <assert.h>
+#include <gtksourceview/gtksource.h>
+
+#include <caml/mlvalues.h>
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/callback.h>
+#include <caml/fail.h>
+#include <caml/custom.h>
+#include <caml/callback.h>
+
+#include <wrappers.h>
+#include <ml_glib.h>
+#include <ml_gdk.h>
+#include <ml_gtk.h>
+#include <ml_gobject.h>
+#include <ml_gdkpixbuf.h>
+#include <ml_pango.h>
+#include <ml_gtktext.h>
+#include <gtk_tags.h>
+#include <gdk_tags.h>
+#include "sourceView4_tags.h"
+#include "sourceView4_tags.c"
+
+#include <string.h>
+
+/* Not in gtksourceview 3.0
+Make_OptFlags_val(Source_search_flag_val)
+*/
+
+/* Already in ml_gobject.c
+Make_Val_final_pointer_ext(GObject, _sink, g_object_ref_sink, ml_g_object_unref_later, 20)
+*/
+
+CAMLprim value ml_gtk_source_view_init(value unit)
+{       /* Since these are declared const, must force gcc to call them! */
+    GType t =
+      gtk_source_completion_get_type() +
+      gtk_source_completion_context_get_type() +
+      gtk_source_completion_provider_get_type() +
+      gtk_source_completion_proposal_get_type() +
+      gtk_source_completion_info_get_type() +
+      gtk_source_completion_item_get_type() +
+      gtk_source_completion_provider_get_type() +
+      gtk_source_style_scheme_get_type() +
+      gtk_source_style_scheme_manager_get_type() +
+      gtk_source_language_get_type() +
+      gtk_source_language_manager_get_type() +
+      gtk_source_mark_attributes_get_type() +
+      gtk_source_buffer_get_type() +
+      gtk_source_view_get_type();
+    return Val_GType(t);
+}
+
+static gpointer string_val(value v)
+{
+	return String_val(v);
+}
+
+GSList *ml_gslist_of_string_list(value list)
+{
+	return GSList_val(list, string_val);
+}
+
+#define GtkSourceCompletionProvider_val(val) check_cast(GTK_SOURCE_COMPLETION_PROVIDER,val)
+#define Val_GtkSourceCompletionProvider(val) (Val_GObject((GObject*)val))
+#define Val_GtkSourceCompletionProvider_new(val) (Val_GObject_new((GObject*)val))
+
+#define GtkSourceCompletionItem_val(val) check_cast(GTK_SOURCE_COMPLETION_ITEM,val)
+#define Val_GtkSourceCompletionItem(val) (Val_GObject((GObject*)val))
+#define Val_GtkSourceCompletionItem_new(val) (Val_GObject_new((GObject*)val))
+
+#define GtkSourceCompletionProposal_val(val) check_cast(GTK_SOURCE_COMPLETION_PROPOSAL,val)
+#define Val_GtkSourceCompletionProposal(val) (Val_GObject((GObject*)val))
+#define Val_GtkSourceCompletionProposal_new(val) (Val_GObject_new((GObject*)val))
+
+#define GtkSourceCompletionInfo_val(val) check_cast(GTK_SOURCE_COMPLETION_INFO,val)
+#define Val_GtkSourceCompletionInfo(val) (Val_GObject((GObject*)val))
+#define Val_GtkSourceCompletionInfo_new(val) (Val_GObject_sink((GObject*)val))
+
+#define GtkSourceCompletionContext_val(val) check_cast(GTK_SOURCE_COMPLETION_CONTEXT,val)
+#define Val_GtkSourceCompletionContext(val) (Val_GObject((GObject*)val))
+#define Val_GtkSourceCompletionContext_new(val) (Val_GObject_sink((GObject*)val))
+// static Make_Val_option(GtkSourceCompletionContext)
+
+#define GtkSourceCompletion_val(val) check_cast(GTK_SOURCE_COMPLETION,val)
+#define Val_GtkSourceCompletion(val) (Val_GObject((GObject*)val))
+#define Val_GtkSourceCompletion_new(val) (Val_GObject_sink((GObject*)val))
+// static Make_Val_option(GtkSourceCompletion)
+
+#define GtkSourceStyleScheme_val(val) check_cast(GTK_SOURCE_STYLE_SCHEME,val)
+#define Val_GtkSourceStyleScheme(val) (Val_GObject((GObject*)val))
+#define Val_GtkSourceStyleScheme_new(val) (Val_GObject_new((GObject*)val))
+static Make_Val_option(GtkSourceStyleScheme)
+
+#define GtkSourceStyleSchemeManager_val(val) \
+     check_cast(GTK_SOURCE_STYLE_SCHEME_MANAGER,val)
+#define Val_GtkSourceStyleSchemeManager(val) (Val_GObject((GObject*)val))
+
+#define Val_GtkSourceLanguage(val)  (Val_GObject((GObject*)val))
+static Make_Val_option(GtkSourceLanguage)
+
+#define GtkSourceLanguage_val(val) check_cast(GTK_SOURCE_LANGUAGE,val)
+#define GtkSourceLanguageManager_val(val)\
+	check_cast(GTK_SOURCE_LANGUAGE_MANAGER,val)
+#define Val_GtkSourceLanguageManager(val)  (Val_GObject((GObject*)val))
+
+#define GtkSourceTagStyle_val(val) Pointer_val(val)
+
+#define GtkSourceMark_val(val) check_cast(GTK_SOURCE_MARK,val)
+#define Val_GtkSourceMark(val)  (Val_GObject((GObject*)val))
+#define Val_GtkSourceMark_new(val) (Val_GObject_new((GObject*)val))
+static Make_Val_option(GtkSourceMark)
+
+#define GtkSourceMarkAttributes_val(val) check_cast(GTK_SOURCE_MARK_ATTRIBUTES,val)
+#define Val_GtkSourceMarkAttributes(val)  (Val_GObject((GObject*)val))
+#define Val_GtkSourceMarkAttributes_new(val) (Val_GObject_new((GObject*)val))
+
+#define GtkSourceUndoManager_val(val) check_cast(GTK_SOURCE_UNDO_MANAGER,val)
+#define Val_GtkSourceUndoManager(val) (Val_GObject((GObject*)val))
+#define Val_GtkSourceUndoManager_new(val) (Val_GObject_new((GObject*)val))
+
+#define GtkSourceBuffer_val(val) check_cast(GTK_SOURCE_BUFFER,val)
+#define Val_GtkSourceBuffer(val) (Val_GObject((GObject*)val))
+#define Val_GtkSourceBuffer_new(val) (Val_GObject_new((GObject*)val))
+#define GtkSourceView_val(val) check_cast(GTK_SOURCE_VIEW,val)
+#define GtkTextIter_val(val) ((GtkTextIter*)MLPointer_val(val))
+#define Val_GtkTextIter(it) (copy_memblock_indirected(it,sizeof(GtkTextIter)))
+#define string_list_of_GSList(l) Val_GSList(l, (value_in) Val_string)
+
+#define GdkPixbuf_option_val(val) Option_val(val, GdkPixbuf_val, NULL)
+#define GdkColor_option_val(val) Option_val(val, GdkColor_val, NULL)
+
+static value val_gtksourcemark(gpointer v)
+{
+  return Val_GtkSourceMark(v);
+}
+
+value source_marker_list_of_GSList(gpointer list)
+{
+  return Val_GSList(list, val_gtksourcemark);
+}
+
+static value val_gtksourcelanguage(gpointer v)
+{
+  return Val_GtkSourceLanguage(v);
+}
+
+value source_language_list_of_GSList(gpointer list)
+{
+  return Val_GSList(list, val_gtksourcelanguage);
+}
+
+// Completion
+
+Make_Flags_val(Source_completion_activation_flags_val)
+#define Val_Activation_flags(val) \
+     ml_lookup_flags_getter(ml_table_source_completion_activation_flags, val)
+
+// Completion provider
+
+typedef struct _CustomObject CustomCompletionProvider;
+typedef struct _CustomObjectClass CustomCompletionProviderClass;
+
+struct _CustomObject
+{
+  GObject parent;      /* this MUST be the first member */
+  value* caml_object;
+};
+
+struct _CustomObjectClass
+{
+  GObjectClass parent;      /* this MUST be the first member */
+};
+
+typedef struct _CustomObject CustomObject;
+typedef struct _CustomObjectClass CustomObjectClass;
+
+static void custom_object_finalize (GObject *object) {
+  GObjectClass *parent_class;
+  CustomObject* custom = (CustomObject*) object;
+  parent_class = (GObjectClass*) g_type_class_peek_parent (object);
+  ml_global_root_destroy(custom->caml_object);
+  (*parent_class->finalize)(object);
+}
+
+GType custom_completion_provider_get_type();
+
+#define TYPE_CUSTOM_COMPLETION_PROVIDER (custom_completion_provider_get_type ())
+#define IS_CUSTOM_COMPLETION_PROVIDER(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TYPE_CUSTOM_COMPLETION_PROVIDER))
+#define METHOD(obj, n) (Field(*(obj->caml_object), n))
+// #define METHOD(obj, name) (callback(caml_get_public_method(obj->caml_object, hash_variant(name)), obj->caml_object))
+#define METHOD1(obj, n, arg1) (callback(Field(*(obj->caml_object), n), arg1))
+#define METHOD2(obj, n, arg1, arg2) (callback2(Field(*(obj->caml_object), n), arg1, arg2))
+#define METHOD3(obj, n, arg1, arg2, arg3) (callback3(Field(*(obj->caml_object), n), arg1, arg2, arg3))
+
+CAMLprim value ml_custom_completion_provider_new (value obj) {
+  CAMLparam1(obj);
+  CustomCompletionProvider* p = (CustomCompletionProvider*) g_object_new (TYPE_CUSTOM_COMPLETION_PROVIDER, NULL);
+  g_assert (p != NULL);
+  p->caml_object = ml_global_root_new(obj);
+  CAMLreturn (Val_GtkSourceCompletionProvider_new(p));
+}
+
+gchar* custom_completion_provider_get_name (GtkSourceCompletionProvider* p) {
+  g_return_val_if_fail (IS_CUSTOM_COMPLETION_PROVIDER(p), NULL);
+  CustomCompletionProvider *obj = (CustomCompletionProvider *) p;
+  return g_strdup(string_val (METHOD1(obj, 0, Val_unit)));
+}
+
+GdkPixbuf* custom_completion_provider_get_icon (GtkSourceCompletionProvider* p) {
+  g_return_val_if_fail (IS_CUSTOM_COMPLETION_PROVIDER(p), NULL);
+  CustomCompletionProvider *obj = (CustomCompletionProvider *) p;
+  return GdkPixbuf_option_val (METHOD1(obj, 1, Val_unit));
+}
+
+void custom_completion_provider_populate (GtkSourceCompletionProvider* p, GtkSourceCompletionContext *context) {
+  g_return_if_fail (IS_CUSTOM_COMPLETION_PROVIDER(p));
+  CustomCompletionProvider *obj = (CustomCompletionProvider *) p;
+  METHOD1(obj, 2, Val_GtkSourceCompletionContext(context));
+}
+
+GtkSourceCompletionActivation custom_completion_provider_get_activation (GtkSourceCompletionProvider* p) {
+  g_return_val_if_fail (IS_CUSTOM_COMPLETION_PROVIDER(p), 0);
+  CustomCompletionProvider *obj = (CustomCompletionProvider *) p;
+  return Flags_Source_completion_activation_flags_val (METHOD1(obj, 3, Val_unit));
+}
+
+gboolean custom_completion_provider_match (GtkSourceCompletionProvider* p, GtkSourceCompletionContext *context) {
+  g_return_val_if_fail (IS_CUSTOM_COMPLETION_PROVIDER(p), FALSE);
+  CustomCompletionProvider *obj = (CustomCompletionProvider *) p;
+  return Bool_val (METHOD1(obj, 4, Val_GtkSourceCompletionContext(context)));
+}
+
+GtkWidget* custom_completion_provider_get_info_widget (GtkSourceCompletionProvider* p, GtkSourceCompletionProposal *proposal) {
+  g_return_val_if_fail (IS_CUSTOM_COMPLETION_PROVIDER(p), NULL);
+  CustomCompletionProvider *obj = (CustomCompletionProvider *) p;
+  return Option_val (METHOD1(obj, 5, Val_GtkSourceCompletionProposal(proposal)), GtkWidget_val, NULL);
+}
+
+void custom_completion_provider_update_info
+  (GtkSourceCompletionProvider* p, GtkSourceCompletionProposal *proposal, GtkSourceCompletionInfo *info) {
+  g_return_if_fail (IS_CUSTOM_COMPLETION_PROVIDER(p));
+  CustomCompletionProvider *obj = (CustomCompletionProvider *) p;
+  METHOD2(obj, 6, Val_GtkSourceCompletionProposal(proposal), Val_GtkSourceCompletionInfo(info));
+}
+
+gboolean custom_completion_provider_get_start_iter
+  (GtkSourceCompletionProvider* p, GtkSourceCompletionContext *context, GtkSourceCompletionProposal *proposal, GtkTextIter *iter) {
+  g_return_val_if_fail (IS_CUSTOM_COMPLETION_PROVIDER(p), FALSE);
+  CustomCompletionProvider *obj = (CustomCompletionProvider *) p;
+  return Bool_val (METHOD3(obj, 7, Val_GtkSourceCompletionContext(context), Val_GtkSourceCompletionProposal(proposal), Val_GtkTextIter(iter)));
+}
+
+gboolean custom_completion_provider_activate_proposal
+  (GtkSourceCompletionProvider* p, GtkSourceCompletionProposal *proposal, GtkTextIter *iter) {
+  g_return_val_if_fail (IS_CUSTOM_COMPLETION_PROVIDER(p), FALSE);
+  CustomCompletionProvider *obj = (CustomCompletionProvider *) p;
+  return Bool_val (METHOD2(obj, 8, Val_GtkSourceCompletionProposal(proposal), Val_GtkTextIter(iter)));
+}
+
+gint custom_completion_provider_get_interactive_delay (GtkSourceCompletionProvider* p) {
+  g_return_val_if_fail (IS_CUSTOM_COMPLETION_PROVIDER(p), 0);
+  CustomCompletionProvider *obj = (CustomCompletionProvider *) p;
+  return Int_val (METHOD1(obj, 9, Val_unit));
+}
+
+gint custom_completion_provider_get_priority (GtkSourceCompletionProvider* p) {
+  g_return_val_if_fail (IS_CUSTOM_COMPLETION_PROVIDER(p), 0);
+  CustomCompletionProvider *obj = (CustomCompletionProvider *) p;
+  return Int_val (METHOD1(obj, 10, Val_unit));
+}
+
+static void custom_completion_provider_interface_init (GtkSourceCompletionProviderIface *iface, gpointer data)
+{
+  iface->get_name = custom_completion_provider_get_name;
+  iface->get_icon = custom_completion_provider_get_icon;
+  iface->populate = custom_completion_provider_populate;
+  iface->match = custom_completion_provider_match;
+  iface->get_activation = custom_completion_provider_get_activation;
+  iface->get_info_widget = custom_completion_provider_get_info_widget;
+  iface->update_info = custom_completion_provider_update_info;
+  iface->get_start_iter = custom_completion_provider_get_start_iter;
+  iface->activate_proposal = custom_completion_provider_activate_proposal;
+  iface->get_interactive_delay = custom_completion_provider_get_interactive_delay;
+  iface->get_priority = custom_completion_provider_get_priority;
+}
+
+static void custom_completion_provider_class_init (CustomCompletionProviderClass *c)
+{
+  GObjectClass *object_class;
+  object_class = (GObjectClass*) c;
+  object_class->finalize = custom_object_finalize;
+}
+
+GType custom_completion_provider_get_type (void)
+{
+  /* Some boilerplate type registration stuff */
+  static GType custom_completion_provider_type = 0;
+
+  if (custom_completion_provider_type == 0)
+  {
+    const GTypeInfo custom_completion_provider_info =
+    {
+      sizeof (CustomCompletionProviderClass),
+      NULL,                                         /* base_init */
+      NULL,                                         /* base_finalize */
+      (GClassInitFunc) custom_completion_provider_class_init,
+      NULL,                                         /* class finalize */
+      NULL,                                         /* class_data */
+      sizeof (CustomCompletionProvider),
+      0,                                           /* n_preallocs */
+      NULL
+    };
+
+    static const GInterfaceInfo source_completion_provider_info =
+    {
+      (GInterfaceInitFunc) custom_completion_provider_interface_init,
+      NULL,
+      NULL
+    };
+
+    custom_completion_provider_type = g_type_register_static (G_TYPE_OBJECT, "custom_completion_provider",
+                                               &custom_completion_provider_info, (GTypeFlags)0);
+
+    /* Here we register our GtkTreeModel interface with the type system */
+    g_type_add_interface_static (custom_completion_provider_type, GTK_SOURCE_TYPE_COMPLETION_PROVIDER, &source_completion_provider_info);
+  }
+
+  return custom_completion_provider_type;
+}
+
+ML_1 (gtk_source_completion_provider_get_name, GtkSourceCompletionProvider_val, Val_string)
+ML_1 (gtk_source_completion_provider_get_icon, GtkSourceCompletionProvider_val, Val_option_GdkPixbuf)
+ML_2 (gtk_source_completion_provider_populate, GtkSourceCompletionProvider_val, GtkSourceCompletionContext_val, Unit)
+ML_1 (gtk_source_completion_provider_get_activation, GtkSourceCompletionProvider_val,
+      Val_Activation_flags)
+ML_2 (gtk_source_completion_provider_match, GtkSourceCompletionProvider_val,
+      GtkSourceCompletionContext_val, Val_bool)
+// FIXME : this should return a widget option?
+ML_2 (gtk_source_completion_provider_get_info_widget,
+      GtkSourceCompletionProvider_val, GtkSourceCompletionProposal_val, Val_GtkWidget)
+ML_3 (gtk_source_completion_provider_update_info, GtkSourceCompletionProvider_val,
+      GtkSourceCompletionProposal_val, GtkSourceCompletionInfo_val, Unit)
+CAMLprim value ml_gtk_source_completion_provider_get_start_iter (value provider, value context, value proposal) {
+  CAMLparam3(provider, context, proposal);
+  GtkTextIter res;
+  gtk_source_completion_provider_get_start_iter(GtkSourceCompletionProvider_val(provider),
+    GtkSourceCompletionContext_val(context), GtkSourceCompletionProposal_val(proposal), &res);
+  CAMLreturn(Val_GtkTextIter(&res));
+}
+ML_3 (gtk_source_completion_provider_activate_proposal, GtkSourceCompletionProvider_val,
+      GtkSourceCompletionProposal_val, GtkTextIter_val, Val_bool)
+ML_1 (gtk_source_completion_provider_get_interactive_delay, GtkSourceCompletionProvider_val,
+      Val_int)
+ML_1 (gtk_source_completion_provider_get_priority, GtkSourceCompletionProvider_val,
+      Val_int)
+
+// Completion proposal
+
+ML_0 (gtk_source_completion_item_new, Val_GtkSourceCompletionItem_new)
+
+// Completion info
+
+ML_3 (gtk_source_completion_info_move_to_iter,
+      GtkSourceCompletionInfo_val, GtkTextView_val, GtkTextIter_val, Unit)
+
+// Completion context
+
+CAMLexport value Val_GtkSourceCompletionProposal_func(gpointer w) {
+  return Val_GtkSourceCompletionProposal(w);
+}
+
+CAMLexport gpointer GtkSourceCompletionProposal_val_func(value val) {
+  CAMLparam1(val);
+  CAMLreturnT (gpointer, GtkSourceCompletionProposal_val(val));
+}
+
+#define Val_Proposals(val) Val_GList(val, Val_GtkSourceCompletionProposal_func)
+#define Proposals_val(val) GList_val(val, GtkSourceCompletionProposal_val_func)
+
+CAMLexport value ml_gtk_source_completion_context_set_activation (value context, value flags) {
+  g_object_set (GtkSourceCompletionContext_val(context),
+                "activation", Flags_Source_completion_activation_flags_val(flags), NULL);
+  return Val_unit;
+}
+
+ML_1 (gtk_source_completion_context_get_activation,
+      GtkSourceCompletionContext_val, Val_Activation_flags)
+ML_4 (gtk_source_completion_context_add_proposals,
+      GtkSourceCompletionContext_val, GtkSourceCompletionProvider_val, Proposals_val, Bool_val, Unit)
+
+ML_1 (gtk_source_completion_block_interactive, GtkSourceCompletion_val, Unit)
+
+CAMLexport value Val_GtkSourceCompletionProvider_func(gpointer w) {
+  return Val_GtkSourceCompletionProvider(w);
+}
+
+CAMLexport gpointer GtkSourceCompletionProvider_val_func(value val) {
+  return GtkSourceCompletionProvider_val(val);
+}
+
+#define Val_Providers(val) Val_GList(val, Val_GtkSourceCompletionProvider_func)
+#define Providers_val(val) GList_val(val, GtkSourceCompletionProvider_val_func)
+
+CAMLexport value ml_gtk_source_completion_add_provider (value completion, value provider) {
+  return Val_bool (gtk_source_completion_add_provider
+    (GtkSourceCompletion_val(completion), GtkSourceCompletionProvider_val(provider), NULL));
+}
+
+CAMLexport value ml_gtk_source_completion_remove_provider (value completion, value provider) {
+  return Val_bool (gtk_source_completion_remove_provider
+    (GtkSourceCompletion_val(completion), GtkSourceCompletionProvider_val(provider), NULL));
+}
+
+ML_1 (gtk_source_completion_get_providers, GtkSourceCompletion_val, Val_Providers)
+ML_1 (gtk_source_completion_hide, GtkSourceCompletion_val, Unit)
+
+// gtk_source_completion_get_info_window
+ML_1 (gtk_source_completion_get_view, GtkSourceCompletion_val, Val_GtkSourceBuffer)
+ML_2 (gtk_source_completion_create_context, GtkSourceCompletion_val, GtkTextIter_val, Val_GtkSourceCompletionContext_new)
+ML_1 (gtk_source_completion_unblock_interactive, GtkSourceCompletion_val, Unit)
+
+// Style
+
+ML_1 (gtk_source_style_scheme_get_name, GtkSourceStyleScheme_val, Val_string)
+ML_1 (gtk_source_style_scheme_get_description, GtkSourceStyleScheme_val, Val_string)
+
+ML_0 (gtk_source_style_scheme_manager_new, Val_GtkAny_sink)
+ML_0 (gtk_source_style_scheme_manager_get_default,
+      Val_GtkSourceStyleSchemeManager)
+ML_2 (gtk_source_style_scheme_manager_get_scheme,
+      GtkSourceStyleSchemeManager_val, String_val,
+      Val_option_GtkSourceStyleScheme)
+ML_1 (gtk_source_style_scheme_manager_get_scheme_ids,
+      GtkSourceStyleSchemeManager_val, string_list_of_strv)
+ML_1 (gtk_source_style_scheme_manager_get_search_path,
+      GtkSourceStyleSchemeManager_val, string_list_of_strv)
+ML_2 (gtk_source_style_scheme_manager_set_search_path,
+      GtkSourceStyleSchemeManager_val, strv_of_string_list, Unit)
+ML_2 (gtk_source_style_scheme_manager_prepend_search_path,
+      GtkSourceStyleSchemeManager_val, String_val, Unit)
+ML_2 (gtk_source_style_scheme_manager_append_search_path,
+      GtkSourceStyleSchemeManager_val, String_val, Unit)
+ML_1 (gtk_source_style_scheme_manager_force_rescan,
+      GtkSourceStyleSchemeManager_val, Unit)
+
+ML_1 (gtk_source_language_get_id, GtkSourceLanguage_val, Val_string)
+ML_1 (gtk_source_language_get_name, GtkSourceLanguage_val, Val_string)
+ML_1 (gtk_source_language_get_section, GtkSourceLanguage_val, Val_string)
+ML_1 (gtk_source_language_get_hidden, GtkSourceLanguage_val, Val_bool)
+
+ML_2 (gtk_source_language_get_metadata, GtkSourceLanguage_val,
+      String_option_val, Val_optstring)
+
+ML_1 (gtk_source_language_get_mime_types, GtkSourceLanguage_val,
+      string_list_of_strv2)
+ML_1 (gtk_source_language_get_globs, GtkSourceLanguage_val,
+      string_list_of_strv2)
+
+ML_2 (gtk_source_language_get_style_name, GtkSourceLanguage_val, String_val,
+      Val_optstring)
+
+ML_1 (gtk_source_language_get_style_ids, GtkSourceLanguage_val,
+      string_list_of_strv2)
+
+
+ML_0 (gtk_source_language_manager_new, Val_GtkAny_sink)
+
+ML_0(gtk_source_language_manager_get_default,Val_GtkSourceLanguageManager)
+
+/* This function leaks the strv. It needs to be freed before returning. */
+ML_2(gtk_source_language_manager_set_search_path,GtkSourceLanguageManager_val,
+     strv_of_string_list,Unit)
+
+#if 0
+// I need to find a test for this code
+CAMLprim value ml_gtk_source_language_manager_set_search_path(value lm, value sl)
+{
+  gchar** strv = strv_of_string_list(sl);
+  gchar **index = strv;
+  gtk_source_language_manager_set_search_path(GtkSourceLanguageManager_val(lm),strv);
+
+  while(*index != NULL) {g_free(*strv); strv++; };
+  g_free(strv);
+  return Val_unit;
+}
+#endif
+
+ML_1(gtk_source_language_manager_get_search_path,GtkSourceLanguageManager_val,
+     string_list_of_strv)
+ML_1(gtk_source_language_manager_get_language_ids,GtkSourceLanguageManager_val,
+     string_list_of_strv)
+ML_2(gtk_source_language_manager_get_language,GtkSourceLanguageManager_val,
+     String_val,Val_option_GtkSourceLanguage)
+ML_3 (gtk_source_language_manager_guess_language, GtkSourceLanguageManager_val,
+      String_option_val, String_option_val, Val_option_GtkSourceLanguage)
+
+
+ML_2 (gtk_source_mark_new, String_val, String_val, Val_GtkSourceMark_new)
+
+ML_1 (gtk_source_mark_get_category, GtkSourceMark_val, Val_string)
+ML_2 (gtk_source_mark_next, GtkSourceMark_val, String_option_val, Val_option_GtkSourceMark)
+ML_2 (gtk_source_mark_prev, GtkSourceMark_val, String_option_val, Val_option_GtkSourceMark)
+
+// SourceMarkAttributes
+
+ML_0(gtk_source_mark_attributes_new, Val_GtkSourceMarkAttributes_new)
+ML_4(gtk_source_view_set_mark_attributes, GtkSourceView_val, String_val,
+     GtkSourceMarkAttributes_val, Int_val, Unit)
+
+CAMLprim value ml_gtk_source_view_get_mark_attributes(
+  value obj, value category) {
+  CAMLparam2(obj,category);
+  CAMLlocal2(attr_opt,result);
+  GtkSourceMarkAttributes* attributes;
+  int prio;
+  attributes =
+    gtk_source_view_get_mark_attributes(
+      GtkSourceView_val(obj), String_val(category), &prio);
+  if (attributes) {
+    attr_opt = Val_copy(attributes);
+    result = alloc_small(1,0);
+    Field(result,0) = attr_opt;
+  }
+  else
+    result = Val_unit;
+  CAMLreturn(result);
+}
+
+CAMLprim value ml_gtk_source_view_get_mark_priority(
+  value obj, value category) {
+  CAMLparam2(obj, category);
+  int prio = 0;
+  gtk_source_view_get_mark_attributes(
+    GtkSourceView_val(obj), String_val(category), &prio);
+  CAMLreturn(Val_int(prio));
+}
+
+// SourceUndoManager
+
+// Defining a custom one: boilerplate
+
+typedef struct _CustomObject CustomUndoManager;
+typedef struct _CustomObjectClass CustomUndoManagerClass;
+
+GType custom_undo_manager_get_type();
+
+#define TYPE_CUSTOM_UNDO_MANAGER (custom_undo_manager_get_type ())
+#define IS_CUSTOM_UNDO_MANAGER(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), TYPE_CUSTOM_UNDO_MANAGER))
+
+CAMLprim value ml_custom_undo_manager_new (value obj) {
+  CAMLparam1(obj);
+  CustomUndoManager* p = (CustomUndoManager*) g_object_new (TYPE_CUSTOM_UNDO_MANAGER, NULL);
+  g_assert (p != NULL);
+  p->caml_object = ml_global_root_new(obj);
+  CAMLreturn (Val_GtkSourceUndoManager_new(p));
+}
+
+gboolean custom_undo_manager_can_undo (GtkSourceUndoManager* p) {
+  g_return_val_if_fail (IS_CUSTOM_UNDO_MANAGER(p), FALSE);
+  CustomUndoManager *obj = (CustomUndoManager *) p;
+  return Bool_val (METHOD1(obj, 0, Val_unit));
+}
+
+gboolean custom_undo_manager_can_redo (GtkSourceUndoManager* p) {
+  g_return_val_if_fail (IS_CUSTOM_UNDO_MANAGER(p), FALSE);
+  CustomUndoManager *obj = (CustomUndoManager *) p;
+  return Bool_val (METHOD1(obj, 1, Val_unit));
+}
+
+void custom_undo_manager_undo (GtkSourceUndoManager* p) {
+  g_return_if_fail (IS_CUSTOM_UNDO_MANAGER(p));
+  CustomUndoManager *obj = (CustomUndoManager *) p;
+  METHOD1(obj, 2, Val_unit);
+}
+
+void custom_undo_manager_redo (GtkSourceUndoManager* p) {
+  g_return_if_fail (IS_CUSTOM_UNDO_MANAGER(p));
+  CustomUndoManager *obj = (CustomUndoManager *) p;
+  METHOD1(obj, 3, Val_unit);
+}
+
+void custom_undo_manager_begin_not_undoable_action (GtkSourceUndoManager* p) {
+  g_return_if_fail (IS_CUSTOM_UNDO_MANAGER(p));
+  CustomUndoManager *obj = (CustomUndoManager *) p;
+  METHOD1(obj, 4, Val_unit);
+}
+
+void custom_undo_manager_end_not_undoable_action (GtkSourceUndoManager* p) {
+  g_return_if_fail (IS_CUSTOM_UNDO_MANAGER(p));
+  CustomUndoManager *obj = (CustomUndoManager *) p;
+  METHOD1(obj, 5, Val_unit);
+}
+
+void custom_undo_manager_can_undo_changed (GtkSourceUndoManager* p) {
+  g_return_if_fail (IS_CUSTOM_UNDO_MANAGER(p));
+  CustomUndoManager *obj = (CustomUndoManager *) p;
+  METHOD1(obj, 6, Val_unit);
+}
+
+void custom_undo_manager_can_redo_changed (GtkSourceUndoManager* p) {
+  g_return_if_fail (IS_CUSTOM_UNDO_MANAGER(p));
+  CustomUndoManager *obj = (CustomUndoManager *) p;
+  METHOD1(obj, 7, Val_unit);
+}
+
+void custom_undo_manager_class_init (CustomUndoManagerClass* c) {
+  GObjectClass *object_class;
+  object_class = (GObjectClass*) c;
+  object_class->finalize = custom_object_finalize;
+}
+
+void custom_undo_manager_interface_init (GtkSourceUndoManagerIface *iface, gpointer data) {
+  iface->can_undo = custom_undo_manager_can_undo;
+  iface->can_redo = custom_undo_manager_can_redo;
+  iface->undo = custom_undo_manager_undo;
+  iface->redo = custom_undo_manager_redo;
+  iface->begin_not_undoable_action = custom_undo_manager_begin_not_undoable_action;
+  iface->end_not_undoable_action = custom_undo_manager_end_not_undoable_action;
+  iface->can_undo_changed = custom_undo_manager_can_undo_changed;
+  iface->can_redo_changed = custom_undo_manager_can_redo_changed;
+}
+
+GType custom_undo_manager_get_type (void)
+{
+  /* Some boilerplate type registration stuff */
+  static GType custom_undo_manager_type = 0;
+
+  if (custom_undo_manager_type == 0)
+  {
+    const GTypeInfo custom_undo_manager_info =
+    {
+      sizeof (CustomUndoManagerClass),
+      NULL,                                         /* base_init */
+      NULL,                                         /* base_finalize */
+      (GClassInitFunc) custom_undo_manager_class_init,
+      NULL,                                         /* class finalize */
+      NULL,                                         /* class_data */
+      sizeof (CustomUndoManager),
+      0,                                           /* n_preallocs */
+      NULL
+    };
+
+    static const GInterfaceInfo source_undo_manager_info =
+    {
+      (GInterfaceInitFunc) custom_undo_manager_interface_init,
+      NULL,
+      NULL
+    };
+
+    custom_undo_manager_type = g_type_register_static (G_TYPE_OBJECT, "custom_undo_manager",
+                                               &custom_undo_manager_info, (GTypeFlags)0);
+
+    /* Here we register our GtkTreeModel interface with the type system */
+    g_type_add_interface_static (custom_undo_manager_type, GTK_SOURCE_TYPE_UNDO_MANAGER, &source_undo_manager_info);
+  }
+
+  return custom_undo_manager_type;
+}
+
+
+ML_1 (gtk_source_undo_manager_can_undo, GtkSourceUndoManager_val, Val_bool)
+ML_1 (gtk_source_undo_manager_can_redo, GtkSourceUndoManager_val, Val_bool)
+ML_1 (gtk_source_undo_manager_undo, GtkSourceUndoManager_val, Unit)
+ML_1 (gtk_source_undo_manager_redo, GtkSourceUndoManager_val, Unit)
+ML_1 (gtk_source_undo_manager_begin_not_undoable_action, GtkSourceUndoManager_val, Unit)
+ML_1 (gtk_source_undo_manager_end_not_undoable_action, GtkSourceUndoManager_val, Unit)
+ML_1 (gtk_source_undo_manager_can_undo_changed, GtkSourceUndoManager_val, Unit)
+ML_1 (gtk_source_undo_manager_can_redo_changed, GtkSourceUndoManager_val, Unit)
+
+// SourceBuffer
+
+ML_1 (gtk_source_buffer_new, GtkTextTagTable_val, Val_GtkSourceBuffer_new)
+ML_1 (gtk_source_buffer_new_with_language, GtkSourceLanguage_val, Val_GtkAny_sink)
+ML_1 (gtk_source_buffer_can_undo, GtkSourceBuffer_val, Val_bool)
+ML_1 (gtk_source_buffer_can_redo, GtkSourceBuffer_val, Val_bool)
+ML_1 (gtk_source_buffer_undo, GtkSourceBuffer_val, Unit)
+ML_1 (gtk_source_buffer_redo, GtkSourceBuffer_val, Unit)
+ML_1 (gtk_source_buffer_begin_not_undoable_action, GtkSourceBuffer_val, Unit)
+ML_1 (gtk_source_buffer_end_not_undoable_action, GtkSourceBuffer_val, Unit)
+ML_4 (gtk_source_buffer_create_source_mark, GtkSourceBuffer_val,
+      String_option_val, String_option_val, GtkTextIter_val, Val_GtkSourceMark)
+ML_4 (gtk_source_buffer_remove_source_marks, GtkSourceBuffer_val,
+      GtkTextIter_val, GtkTextIter_val, String_option_val, Unit)
+ML_3 (gtk_source_buffer_get_source_marks_at_iter, GtkSourceBuffer_val,
+      GtkTextIter_val,String_option_val, source_marker_list_of_GSList)
+ML_3 (gtk_source_buffer_get_source_marks_at_line, GtkSourceBuffer_val,
+      Int_val,String_option_val, source_marker_list_of_GSList)
+
+ML_3 (gtk_source_buffer_forward_iter_to_source_mark, GtkSourceBuffer_val, GtkTextIter_val, String_option_val, Val_bool)
+ML_3 (gtk_source_buffer_backward_iter_to_source_mark, GtkSourceBuffer_val, GtkTextIter_val, String_option_val, Val_bool)
+
+ML_3 (gtk_source_buffer_iter_has_context_class, GtkSourceBuffer_val,
+      GtkTextIter_val, String_val, Val_bool)
+ML_3 (gtk_source_buffer_iter_forward_to_context_class_toggle,
+      GtkSourceBuffer_val, GtkTextIter_val, String_val, Val_bool)
+ML_3 (gtk_source_buffer_iter_backward_to_context_class_toggle,
+      GtkSourceBuffer_val, GtkTextIter_val, String_val, Val_bool)
+
+ML_3 (gtk_source_buffer_ensure_highlight, GtkSourceBuffer_val,
+      GtkTextIter_val, GtkTextIter_val, Unit)
+
+ML_2 (gtk_source_buffer_set_highlight_matching_brackets, GtkSourceBuffer_val, Bool_val, Unit);
+
+
+ML_0 (gtk_source_view_new, Val_GtkWidget_sink)
+ML_1 (gtk_source_view_new_with_buffer, GtkSourceBuffer_val, Val_GtkWidget_sink)
+
+/* The following are apparently removed in gtksourceview3, replaced by gtk_source_view_get_mark_category (TODO?)
+ML_2 (gtk_source_view_get_mark_category_priority,
+      GtkSourceView_val, String_val, Val_int)
+ML_3 (gtk_source_view_set_mark_category_priority,
+      GtkSourceView_val, String_val, Int_val, Unit)
+ML_3 (gtk_source_view_set_mark_category_pixbuf, GtkSourceView_val,
+      String_val, GdkPixbuf_option_val, Unit)
+ML_2 (gtk_source_view_get_mark_category_pixbuf, GtkSourceView_val,
+      String_val, Val_option_GdkPixbuf)
+ML_3 (gtk_source_view_set_mark_category_background,
+      GtkSourceView_val, String_val, GdkColor_option_val, Unit)
+
+CAMLprim value ml_gtk_source_view_get_mark_category_background
+(value sv, value s, value c) {
+     CAMLparam3(sv, s, c);
+     CAMLlocal2(color, result);
+     GdkColor dest;
+
+     if (gtk_source_view_get_mark_category_background(
+	      GtkSourceView_val(sv), String_val(s), &dest)) {
+	  color = Val_copy(dest);
+	  result = alloc_small(1, 0);
+	  Field(result, 0) = color;
+     }
+     else
+	  result = Val_unit;
+
+     CAMLreturn(result);
+}
+*/
+
+ML_1 (gtk_source_view_get_completion, GtkSourceView_val, Val_GtkSourceCompletion)
+
+/* Make_Flags_val(Source_draw_spaces_flags_val) */
+/* #define Val_flags_Draw_spaces_flags(val) \ */
+/*      ml_lookup_flags_getter(ml_table_source_draw_spaces_flags, val) */
+
+/* XXX */
+/* ML_1 (gtk_source_view_get_draw_spaces, */
+/*       GtkSourceView_val, Val_flags_Draw_spaces_flags) */
+
+/* ML_2 (gtk_source_view_set_draw_spaces, */
+/*       GtkSourceView_val, Flags_Source_draw_spaces_flags_val, Unit) */
+
+/* This code was taken from gedit */
+/* assign a unique name */
+static G_CONST_RETURN gchar *
+get_widget_name (GtkWidget *w)
+{
+        const gchar *name;
+
+        name = gtk_widget_get_name (w);
+        g_return_val_if_fail (name != NULL, NULL);
+
+        if (strcmp (name, g_type_name (G_OBJECT_TYPE (w))) == 0)
+        {
+                static guint d = 0;
+                gchar *n;
+
+                n = g_strdup_printf ("%s_%u_%u", name, d, g_random_int());
+                d++;
+
+                gtk_widget_set_name (w, n);
+                g_free (n);
+
+                name = gtk_widget_get_name (w);
+        }
+
+        return name;
+}
+/* There is no clean way to set the cursor-color, so we are stuck
+ * with the following hack: set the name of each widget and parse
+ * a gtkrc string.
+ */
+static void
+gtk_modify_cursor_color (GtkWidget *textview,
+                     GdkColor  *color)
+{
+        static const char cursor_color_rc[] =
+                "style \"svs-cc\"\n"
+                "{\n"
+                        "GtkSourceView::cursor-color=\"#%04x%04x%04x\"\n"
+                "}\n"
+                "widget \"*.%s\" style : application \"svs-cc\"\n";
+
+        const gchar *name;
+        gchar *rc_temp;
+
+        name = get_widget_name (textview);
+        g_return_if_fail (name != NULL);
+
+        if (color != NULL)
+        {
+                rc_temp = g_strdup_printf (cursor_color_rc,
+                                           color->red,
+                                           color->green,
+                                           color->blue,
+                                           name);
+        }
+        else
+        {
+                GtkRcStyle *rc_style;
+
+                rc_style = gtk_widget_get_modifier_style (textview);
+
+                rc_temp = g_strdup_printf (cursor_color_rc,
+                                           rc_style->text [GTK_STATE_NORMAL].red,
+                                           rc_style->text [GTK_STATE_NORMAL].green,
+                                           rc_style->text [GTK_STATE_NORMAL].blue,
+                                           name);
+        }
+
+        gtk_rc_parse_string (rc_temp);
+        gtk_widget_reset_rc_styles (textview);
+
+        g_free (rc_temp);
+}
+/* end of gedit code */
+
+ML_2(gtk_modify_cursor_color,GtkWidget_val,GdkColor_val,Unit);
+
+/* Not anymore in gtksourceview3; ml_gtk_source_iter_*_search told to be now in gtk+
+#define Make_search(dir) \
+CAMLprim value ml_gtk_source_iter_##dir##_search (value ti,\
+                                                value str,\
+                                                value flag,\
+                                                value ti_stop,\
+                                                value ti_start,\
+                                                value ti_lim)\
+{ CAMLparam5(ti,str,flag,ti_start,ti_stop);\
+  CAMLxparam1(ti_lim);\
+  CAMLlocal2(res,coup);\
+  GtkTextIter* ti1,*ti2;\
+  gboolean b;\
+  ti1=gtk_text_iter_copy(GtkTextIter_val(ti_start));\
+  ti2=gtk_text_iter_copy(GtkTextIter_val(ti_stop));\
+  b=gtk_source_iter_##dir##_search(GtkTextIter_val(ti),\
+                                 String_val(str),\
+                                 OptFlags_Source_search_flag_val(flag),\
+                                 ti1,\
+                                 ti2,\
+                                 Option_val(ti_lim,GtkTextIter_val,NULL));\
+  if (!b) res = Val_unit;\
+  else \
+    { res = alloc(1,0);\
+      coup = alloc_tuple(2);\
+      Store_field(coup,0,Val_GtkTextIter(ti1));\
+      Store_field(coup,1,Val_GtkTextIter(ti2));\
+      Store_field(res,0,coup);};\
+  CAMLreturn(res);}
+
+Make_search(forward);
+Make_search(backward);
+ML_bc6(ml_gtk_source_iter_forward_search);
+ML_bc6(ml_gtk_source_iter_backward_search);
+*/

--- a/src-sourceview4/sourceView4_tags.var
+++ b/src-sourceview4/sourceView4_tags.var
@@ -1,0 +1,44 @@
+(*****************************************************************************)
+(*                                                                           *)
+(*   lablgtksourceview, OCaml binding for the GtkSourceView text widget      *)
+(*                                                                           *)
+(*   Copyright (C) 2005  Stefano Zacchiroli <zack@cs.unibo.it>               *)
+(*   Copyright (C) 2006  Stefano Zacchiroli <zack@cs.unibo.it>               *)
+(*                       Maxence Guesdon <maxence.guesdon@inria.fr>          *)
+(*                                                                           *)
+(*   This library is free software; you can redistribute it and/or modify    *)
+(*   it under the terms of the GNU Lesser General Public License as          *)
+(*   published by the Free Software Foundation; either version 2.1 of the    *)
+(*   License, or (at your option) any later version.                         *)
+(*                                                                           *)
+(*   This library is distributed in the hope that it will be useful, but     *)
+(*   WITHOUT ANY WARRANTY; without even the implied warranty of              *)
+(*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU       *)
+(*   Lesser General Public License for more details.                         *)
+(*                                                                           *)
+(*   You should have received a copy of the GNU Lesser General Public        *)
+(*   License along with this library; if not, write to the Free Software     *)
+(*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307     *)
+(*   USA                                                                     *)
+(*                                                                           *)
+(*****************************************************************************)
+
+package "sourceView4"
+
+(* Not in gtksourceview 3.0
+type source_search_flag = "GTK_SOURCE_SEARCH_"
+  [ `VISIBLE_ONLY | `TEXT_ONLY | `CASE_INSENSITIVE ]
+*)
+
+type source_smart_home_end_type = "GTK_SOURCE_SMART_HOME_END_"
+  [ `DISABLED| `BEFORE| `AFTER| `ALWAYS ]
+
+(* Only NBSP is supported *)
+type source_space_type = "GTK_SOURCE_SPACE_TYPE_"
+  [ `SPACE | `TAB | `NEWLINE | `NBSP ]
+
+type source_space_location_type = "GTK_SOURCE_SPACE_LOCATION_"
+  [ `LEADING | `TRAILING ]
+
+type source_completion_activation_flags = "GTK_SOURCE_COMPLETION_ACTIVATION_"
+  [ `INTERACTIVE | `USER_REQUESTED ]


### PR DESCRIPTION
- main changes are in the completion API, see
  https://developer.gnome.org/gtksourceview/stable/porting-guide-3-to-4.html

- todos:

  + implement new completion API [present already in sourceview3 but prefixed]
  + see what happened with `draw_spaces` API, restore

Note that CoqIDE was able to get compiled and is functional with the
current status of this lib, https://github.com/coq/coq/pull/11412