### PR TITLE
Fix compatiblility with OCaml 4.10.0beta2

### DIFF
--- a/src/wrappers.h
+++ b/src/wrappers.h
@@ -34,9 +34,7 @@
 #include <caml/fail.h>
 #include <caml/custom.h>
 #include <caml/version.h>
-#if OCAML_VERSION < 41000
-CAMLextern char *young_start, *young_end; /* from minor_gc.h */
-#endif
+#include <caml/minor_gc.h>
 
 CAMLexport value copy_memblock_indirected (void *src, asize_t size);
 value alloc_memblock_indirected (asize_t size);


### PR DESCRIPTION
After a lot of discussions https://github.com/ocaml/ocaml/pull/9253 has finally been chosen to fix the compatibility issue in the next version of the OCaml compiler, however currently the lablgtk is not compatible with OCaml 4.10 anymore. This PR fixes the issue.