### PR TITLE
Fix the build with -fno-common.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 LablGTK changes log
 
+2020.01.24 [Jerry James]
+  * Fix the build with -fno-common, the default for GCC 10
+
 ## In Lablgtk-3.1.0
 
 2020.01.23 [Jacques]

--- a/src/ml_gdk.c
+++ b/src/ml_gdk.c
@@ -48,6 +48,8 @@
 #include "gdk_tags.h"
 
 
+lookup_info *ml_table_extension_events;
+
 CAMLprim void ml_raise_gdk (const char *errmsg)
 {
   static const value * exn = NULL;

--- a/src/ml_gdk.h
+++ b/src/ml_gdk.h
@@ -86,7 +86,7 @@ CAMLexport value Val_GdkEvent (GdkEvent *);
 CAMLexport int OptFlags_GdkModifier_val (value);
 CAMLexport int Flags_GdkModifier_val (value);
 CAMLexport int Flags_Event_mask_val (value);
-CAMLexport lookup_info *ml_table_extension_events;
+CAMLextern lookup_info *ml_table_extension_events;
 #define Extension_events_val(key) ml_lookup_to_c(ml_table_extension_events,key)
 
 #define GdkDragContext_val(val) check_cast(GDK_DRAG_CONTEXT,val)


### PR DESCRIPTION
GCC has defaulted to -fcommon for many years.  GCC 10 is changing the default to -fno-common, which has led to lablgtk failing to build because every compilation unit that includes ml_gdk.h has its own variable named `ml_table_extension_events`.  This commit ensures that there is exactly one definition of that variable.