### PR TITLE
[dune] Restore compatibility with dune 2.7.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -363,7 +363,7 @@ In Lablgtk-2.14.2:
     function to process messages inside a different main loop.
   * add -nothinit option to lablgtk2, since Quartz cannot run the main
     loop in a different thread (one should just call GtkThread.main).
-    See dialog-thread.ml for an example.
+    See dialog_thread.ml for an example.
 
 2010.06.08 [Jacques]
   * correct interfaces due to the fixing of an unsoundness bug in ocaml 3.12

--- a/examples/dialog_thread.ml
+++ b/examples/dialog_thread.ml
@@ -8,7 +8,7 @@
 
 (* $Id$ *)
 
-(* lablgtk2 -thread -nothinit dialog-thread.ml *)
+(* lablgtk2 -thread -nothinit dialog_thread.ml *)
 
 let _ = GMain.init ()
 let window = GWindow.window ~border_width: 10 ()
@@ -24,7 +24,7 @@ let main () =
   Glib.Timeout.add ~ms:100 ~callback:GtkThread.do_jobs;
   window#connect#destroy ~callback:GMain.quit;
   button#connect#clicked ~callback:(fun () ->
-    let dialog = 
+    let dialog =
       GWindow.message_dialog ~title:"Quit ?"
         ~message_type:`QUESTION ~message:"Quit the application ?"
         ~buttons:GWindow.Buttons.yes_no ()

--- a/examples/dune
+++ b/examples/dune
@@ -8,7 +8,7 @@
    buttons
    cairo_demo calc calendar cgets
    combobox counter dcalendar
-   dialog-thread drawing
+   dialog_thread drawing
    editor2
    entry2 entrycompletion entry
    eventbox events2 events expander
@@ -33,7 +33,7 @@
    about accel_tree action assistant assistant_tutorial
    buttons cairo_demo
    calc calendar cgets combobox counter
-   dcalendar dialog-thread drawing
+   dcalendar dialog_thread drawing
    editor2 entry2 entrycompletion entry eventbox events2 events expander
    fifteen filechooser fixed_editor fixpoint
    gioredirect giotest hello iconview image kaimono


### PR DESCRIPTION
Dear lablgtk maintainers,

With dune lang 2.7 we plan to check that values in the `names` field of `executables` stanza are valid module names. (See [PR#3646](https://github.com/ocaml/dune/pull/3646)) 
Even if the compiler does accepts (with a warning) compilation units whose names are not valid module names. 

This PR restore compatibility with dune 2.7.0 by renaming the `example/dialog-thread` compilation unit.