### PR TITLE
Add partial support for OCaml 5.00

### DIFF
--- a/src/ml_glib.c
+++ b/src/ml_glib.c
@@ -105,7 +105,7 @@ CAMLprim value Val_GList (GList *list, value (*func)(gpointer))
     Field(new_cell,0) = result;
     Field(new_cell,1) = Val_unit;
     if (last_cell == Val_unit) cell = new_cell;
-    else modify(&Field(last_cell,1), new_cell);
+    else caml_modify(&Field(last_cell,1), new_cell);
     last_cell = new_cell;
     list = list->next;
   }
@@ -427,7 +427,7 @@ CAMLprim value Val_GSList (GSList *list, value (*func)(gpointer))
     Field(new_cell,0) = result;
     Field(new_cell,1) = Val_unit;
     if (last_cell == Val_unit) cell = new_cell;
-    else modify(&Field(last_cell,1), new_cell);
+    else caml_modify(&Field(last_cell,1), new_cell);
     last_cell = new_cell;
     list = list->next;
   }

--- a/src/ml_gtk.c
+++ b/src/ml_gtk.c
@@ -920,7 +920,7 @@ CAMLprim value ml_gtk_init (value argv)
     }
 
     argv = (argc ? alloc (argc, 0) : Atom(0));
-    for (i = 0; i < argc; i++) modify(&Field(argv,i), Field(copy,i));
+    for (i = 0; i < argc; i++) caml_modify(&Field(argv,i), Field(copy,i));
     CAMLreturn (argv);
 }
 /* not in 3

--- a/src/ml_gtktree.c
+++ b/src/ml_gtktree.c
@@ -1484,8 +1484,8 @@ CAMLprim value ml_register_custom_model_callback_object(value custom_model,
   GObject *obj = GObject_val(custom_model);
   g_return_val_if_fail (IS_CUSTOM_MODEL (obj),Val_unit);
   if(Is_block(callback_object) &&
-      (char*)callback_object < (char*)young_end &&
-      (char*)callback_object > (char*)young_start)
+      (char*)callback_object < (char*)caml_young_end &&
+      (char*)callback_object > (char*)caml_young_start)
     {
       caml_register_global_root (&callback_object);
       caml_minor_collection();

--- a/src/wrappers.h
+++ b/src/wrappers.h
@@ -35,7 +35,7 @@
 #include <caml/custom.h>
 #include <caml/minor_gc.h>
 #define Is_young_block(v) \
-  (Is_block(v) && (value*)(v) < young_end && (value*)(v) > young_start)
+  (Is_block(v) && (value*)(v) < caml_young_end && (value*)(v) > caml_young_start)
 
 #ifndef Bytes_val
 #define Bytes_val String_val
@@ -278,7 +278,7 @@ CAMLprim value cname##_bc (value *argv, int argn) \
  else if (l <= Max_young_wosize) { int i; ret = alloc_tuple(l); \
    for(i=0;i<l;i++) Field(ret,i) = conv(src[i]); } \
  else { int i; ret = alloc_shr(l,0); \
-   for(i=0;i<l;i++) initialize (&Field(ret,i), conv(src[i])); }
+   for(i=0;i<l;i++) caml_initialize (&Field(ret,i), conv(src[i])); }
 
 #define Make_Val_final_pointer(type, init, final, adv) \
 static void ml_final_##type (value val) \
@@ -289,7 +289,7 @@ static struct custom_operations ml_custom_##type = \
 CAMLprim value Val_##type (type *p) \
 { value ret; if (!p) ml_raise_null_pointer(); \
   ret = ml_alloc_custom (&ml_custom_##type, sizeof(value), adv, 1000); \
-  initialize (&Field(ret,1), (value) p); init(p); return ret; }
+  caml_initialize (&Field(ret,1), (value) p); init(p); return ret; }
 
 #define Make_Val_final_pointer_ext(type, ext, init, final, adv) \
 static void ml_final_##type##ext (value val) \
@@ -300,7 +300,7 @@ static struct custom_operations ml_custom_##type##ext = \
 CAMLprim value Val_##type##ext (type *p) \
 { value ret; if (!p) ml_raise_null_pointer(); \
   ret = ml_alloc_custom (&ml_custom_##type##ext, sizeof(value), adv, 1000); \
-  initialize (&Field(ret,1), (value) p); init(p); return ret; }
+  caml_initialize (&Field(ret,1), (value) p); init(p); return ret; }
 
 #define Make_Val_final_pointer_compare(type, init, comp, final, adv) \
 static void ml_final_##type (value val) \
@@ -313,7 +313,7 @@ static struct custom_operations ml_custom_##type = \
 CAMLprim value Val_##type (type *p) \
 { value ret; if (!p) ml_raise_null_pointer(); \
   ret = ml_alloc_custom (&ml_custom_##type, sizeof(value), adv, 1000); \
-  initialize (&Field(ret,1), (value) p); init(p); return ret; }
+  caml_initialize (&Field(ret,1), (value) p); init(p); return ret; }
 
 #define Pointer_val(val) ((void*)Field(val,1))
 #define Store_pointer(val,p) (Field(val,1)=Val_bp(p))


### PR DESCRIPTION
This PR makes it possible for lablgtk3 to be compiled with ocaml-multicore. However there are still a few warnings here and there and the example program I've tried segfaults, .. Though it's better than nothing and the changes are still relevant in recent versions of OCaml anyway as it simply uses the caml namespace instead of the deprecated functions/values.