### PR TITLE
Some build fixes

### DIFF
--- a/examples/glade/dune
+++ b/examples/glade/dune
@@ -12,8 +12,10 @@
 
 (rule
  (targets project1.ml)
+ (deps project1.ui)
  (action (with-stdout-to %{targets} (run lablgladecc3 project1.ui))))
 
 (rule
  (targets project2.ml)
+ (deps project2.ui)
  (action (with-stdout-to %{targets} (run lablgladecc3 project2.ui))))

--- a/lablgtk3.opam
+++ b/lablgtk3.opam
@@ -21,6 +21,7 @@ depends: [
   "cairo2"    {         >= "0.6"    }
   "conf-gtk3" { build & >= "18"     }
   "ocamlfind" { dev                 }
+  "camlp5"    { dev                 }
 ]
 
 build: [

--- a/lablgtk3.opam
+++ b/lablgtk3.opam
@@ -20,6 +20,7 @@ depends: [
   "dune"      {         >= "1.8.0"  }
   "cairo2"    {         >= "0.6"    }
   "conf-gtk3" { build & >= "18"     }
+  "ocamlfind" { dev                 }
 ]
 
 build: [


### PR DESCRIPTION
I'm attempting to get lablgtk3 to build under ocaml-ci. Here are some fixes that seem to help a bit:

- Add `{dev}` dependency on `camlp5`. Camlp5 is mentioned in the README as needed for local development, but wasn't in the opam file.
-  Add `{dev}` dependency on `ocamlfind`. This seems to be necessary in order for dune to find the `ocamldoc` library (which is currently bundled with OCaml). This is needed to build `gtkdoc`, which doesn't seem to be used for anything, so it's only needed for dev or CI builds (which probably use `dune build @check`).
- The glade rules needed to list the ui files as dependencies.

Even with this, there are still a lot of errors. e.g.

```
File "examples/fixed_editor.ml", line 95, characters 28-45:
95 |       let (width, height) = Drawable.get_size w in
                                 ^^^^^^^^^^^^^^^^^
Error: Unbound module Drawable
```
and
```
File "examples/image.ml", line 63, characters 2-14:
63 |   Gdk.Rgb.init ();
       ^^^^^^^^^^^^
Error: Unbound module Gdk.Rgb
```
I'm not sure where these modules are supposed to be coming from. Maybe they were lost in the move to Gtk3?

See https://ci.ocamllabs.io/github/talex5/lablgtk/commit/b387e8446ede079479a23727cfde5ca748e06533 for the full list.

BTW, if you'd like to enable ocaml-ci on the main repository, just go to https://github.com/apps/ocaml-ci/installations/new and add it to (just) this repository. There's no other setup, but I will need to approve the request, so let me know.