### PR TITLE
Leave blocking section on callback while polling

### DIFF
--- a/src/ml_glib.c
+++ b/src/ml_glib.c
@@ -300,11 +300,15 @@ ML_1 (g_source_remove, Int_val, Unit)
 
 static GPollFunc poll_func = NULL;
 
+int polling = 0;
+
 static gint ml_poll (GPollFD *ufds, guint nfsd, gint timeout)
 {
     gint res;
     caml_enter_blocking_section();
+    polling = 1;
     res = poll_func(ufds, nfsd, timeout);
+    polling = 0;
     caml_leave_blocking_section();
     return res;
 }

--- a/src/ml_glib.h
+++ b/src/ml_glib.h
@@ -37,3 +37,5 @@ CAMLexport GSList *GSList_val (value list, value_out);
 
 CAMLexport void ml_register_exn_map (GQuark domain, char *caml_name);
 CAMLexport void ml_raise_gerror(GError *) Noreturn;
+
+extern int polling;


### PR DESCRIPTION
Fixes #141

See also https://github.com/verifast/verifast/issues/252 . With this patch, the VeriFast IDE works correctly and I can no longer get it to crash.