### PR TITLE
Remove naked pointers and Obj.truncate for compatibility with 5.00

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 LablGTK changes log
 
+2021.12.24[Jacques]
+  * Remove naked pointers and Obj.truncate for compatibility with 5.00 (#144)
+
 2021.12.18 [Jacques]
   * Add WRAP_WIDTH, WRAP_MODE tags to cell_properties_text (#146)
    [Nathan Guermond]

--- a/src-unsupported/ml_gtklist.c
+++ b/src-unsupported/ml_gtklist.c
@@ -167,7 +167,17 @@ ML_2 (gtk_clist_get_selectable, GtkCList_val, Int_val, Val_bool)
 ML_5 (gtk_clist_set_shift, GtkCList_val, Int_val, Int_val, Int_val, Int_val,
       Unit)
 /* ML_2 (gtk_clist_append, GtkCList_val, (char **), Val_int) */
-ML_3 (gtk_clist_insert, GtkCList_val, Int_val, (char **), Val_int)
+/* ML_3 (gtk_clist_insert, GtkCList_val, Int_val, (char **), Val_int) */
+CAMLprim value ml_gtk_clist_insert (value w, value n, value arr)
+{
+     CAMLparam3 (w,n,arr);
+     int i, len = Wosize_val(arr);
+     char** arr0 = (char**) caml_alloc (len, Abstract_tag);
+
+     for (i = 0; i < len; i++) arr0[i] = (char*)String_option_val(Field(arr,i));
+     i = gtk_clist_insert (GtkCList_val(w), Int_val(n), arr0);
+     CAMLreturn (Val_int(i));
+}
 ML_2 (gtk_clist_remove, GtkCList_val, Int_val, Unit)
 CAMLprim value ml_gtk_clist_set_row_data (value w, value row, value data)
 {

--- a/src/gpointer.ml
+++ b/src/gpointer.ml
@@ -32,16 +32,6 @@ let optaddr : 'a option -> 'a optaddr =
       None -> Obj.magic 0
     | Some x -> Obj.magic x
 
-(* naked pointers *)
-type optstring
-
-let raw_null = snd (Obj.magic Nativeint.zero)
-
-let optstring : string option -> optstring =
-  function
-      None -> raw_null
-    | Some x -> Obj.magic x
-
 (* boxed pointers *)
 type boxed
 let boxed_null : boxed = Obj.magic Nativeint.zero

--- a/src/gpointer.mli
+++ b/src/gpointer.mli
@@ -28,11 +28,6 @@
 type 'a optaddr
 val optaddr : 'a option -> 'a optaddr
 
-(** Naked pointers *)
-type optstring
-val raw_null : optstring
-val optstring : string option -> optstring
-
 (** Boxed pointers *)
 type boxed
 val boxed_null : boxed

--- a/src/gtkMain.ml
+++ b/src/gtkMain.ml
@@ -33,6 +33,8 @@ module Main = struct
   (* external set_locale : unit -> string = "ml_gtk_set_locale" *)
   external disable_setlocale : unit -> unit = "ml_gtk_disable_setlocale"
   (* external main : unit -> unit = "ml_gtk_main" *)
+  external _caml_sys_modify_argv : string array -> unit =
+    "caml_sys_modify_argv"
   let init ?(setlocale=true) () =
     let setlocale =
       try Sys.getenv "GTK_SETLOCALE" <> "0" with Not_found -> setlocale in
@@ -44,9 +46,7 @@ module Main = struct
         raise (Error ("GtkMain.init: initialization failed\n" ^ err))
     in
     if setlocale then ignore (Glib.Main.setlocale `NUMERIC (Some "C"));
-    Array.blit ~src:argv ~dst:Sys.argv ~len:(Array.length argv)
-      ~src_pos:0 ~dst_pos:0;
-    Obj.truncate (Obj.repr Sys.argv) (Array.length argv) [@warnerror "-3"];
+    _caml_sys_modify_argv argv;
     if setlocale then Glib.Main.setlocale `ALL None else ""
   open Glib
   let loops = ref []

--- a/src/wrappers.c
+++ b/src/wrappers.c
@@ -177,8 +177,8 @@ CAMLexport value ml_lookup_flags_getter (const lookup_info table[], int data)
   CAMLreturn(l);
 }
 
-ML_2 (ml_lookup_from_c, (lookup_info*), Int_val, 0+)
-ML_2 (ml_lookup_to_c, (lookup_info*), 0+, Val_int)
+ML_2 (ml_lookup_from_c, Lookup_info_val, Int_val, 0+)
+ML_2 (ml_lookup_to_c, Lookup_info_val, 0+, Val_int)
 
 gchar **
 strv_of_string_list (value list)

--- a/src/wrappers.h
+++ b/src/wrappers.h
@@ -60,8 +60,19 @@ char ** strv_of_string_list (value list);
 CAMLprim value *ml_global_root_new (value v);
 CAMLexport void ml_global_root_destroy (void *data);
 
+/* Pointer conversions */
+#define Pointer_val(val) ((void*)Field(val,1))
+#define Store_pointer(val,p) (Field(val,1)=Val_bp(p))
+#define MLPointer_val(val) \
+        ((int)Field(val,1) == 2 ? &Field(val,2) : (void*)Field(val,1))
+
+#define Val_addr(ptr) (1+(value)ptr)
+#define Addr_val(val) ((void*)(val-1))
+
 /* enums <-> polymorphic variants */
 typedef struct { value key; int data; } lookup_info;
+#define Val_lookup_info(v) Val_pointer((void*)v)
+#define Lookup_info_val(v) ((const lookup_info*)Pointer_val(v))
 CAMLexport value ml_lookup_from_c (const lookup_info table[], int data);
 CAMLexport int ml_lookup_to_c (const lookup_info table[], value key);
 CAMLexport value ml_lookup_flags_getter (const lookup_info table[], int data);
@@ -314,14 +325,6 @@ CAMLprim value Val_##type (type *p) \
 { value ret; if (!p) ml_raise_null_pointer(); \
   ret = ml_alloc_custom (&ml_custom_##type, sizeof(value), adv, 1000); \
   caml_initialize (&Field(ret,1), (value) p); init(p); return ret; }
-
-#define Pointer_val(val) ((void*)Field(val,1))
-#define Store_pointer(val,p) (Field(val,1)=Val_bp(p))
-#define MLPointer_val(val) \
-        ((int)Field(val,1) == 2 ? &Field(val,2) : (void*)Field(val,1))
-
-#define Val_addr(ptr) (1+(value)ptr)
-#define Addr_val(val) ((void*)(val-1))
 
 #define Wosize_asize(x) ((x-1)/sizeof(value)+1)
 #define Wosizeof(x) Wosize_asize(sizeof(x))

--- a/tools/propcc.ml
+++ b/tools/propcc.ml
@@ -159,7 +159,7 @@ let string (strm__ : _ Stream.t) =
 
 let may_colon p def (strm__ : _ Stream.t) =
   match Stream.peek strm__ with
-    Some (Kwd ":") -> Stream.junk strm__; let s = strm__ in p s
+    Some (Kwd ":") -> Stream.junk strm__; p strm__
   | _ -> def
 
 let may_string def (strm__ : _ Stream.t) =
@@ -243,7 +243,7 @@ let marshaller (strm__ : _ Stream.t) =
         try star label_type strm__ with
           Stream.Failure -> raise (Stream.Error "")
       in
-      let s = strm__ in return_type (List.split types) s
+      return_type (List.split types) strm__
   | _ -> Types ([], [], "")
 
 let simple_attr (strm__ : _ Stream.t) =

--- a/tools/varcc.ml
+++ b/tools/varcc.ml
@@ -57,7 +57,7 @@ let rec ident_list (strm__ : _ Stream.t) =
           let _ =
             try may_bar strm__ with Stream.Failure -> raise (Stream.Error "")
           in
-          let s = strm__ in (x, trans) :: ident_list s
+          (x, trans) :: ident_list strm__
       | _ -> raise (Stream.Error "")
       end
   | _ -> []

--- a/tools/varcc.ml4
+++ b/tools/varcc.ml4
@@ -162,16 +162,23 @@ let process ic ~hc ~cc =
   with End_of_file ->
     if !all_convs <> [] && !package <> "" then begin
       let oc x = fprintf cc x in
-      oc "CAMLprim value ml_%s_get_tables ()\n{\n" (camlize !package);
-      oc "  static const lookup_info *ml_lookup_tables[] = {\n";
       let convs = List.rev !all_convs in
-      List.iter convs ~f:(fun (s,_,_,_) -> oc "    ml_table_%s,\n" s);
-      oc "  };\n";
-      (* When he have only one conversion, we must return it directly instead of       * an array that would be converted to a tuple *)
+      let len = List.length convs in
+      oc "CAMLprim value ml_%s_get_tables ()\n{\n" (camlize !package);
+      oc "  CAMLparam0 ();\n";
+      oc "  CAMLlocal1 (ml_lookup_tables);\n";
+      oc "  ml_lookup_tables = caml_alloc_tuple(%d);\n" len;
+      List.iteri convs ~f:
+        begin fun i (s,_,_,_) ->
+          oc "  Field(ml_lookup_tables,%d) = Val_lookup_info(ml_table_%s);\n"
+            i s
+        end;
+      (* When we have only one conversion, we must return it directly instead
+         of a one-value array that would be invalid as a tuple *)
       if List.length convs = 1 then
-        oc "  return (value)ml_lookup_tables[0];"
+        oc "  CAMLreturn (Field(ml_lookup_tables,0));\n"
       else
-        oc "  return (value)ml_lookup_tables;";
+        oc "  CAMLreturn (ml_lookup_tables);\n";
       oc "}\n";
       let mlc = open_out (!package ^ "Enums.ml") in
       let ppf = Format.formatter_of_out_channel mlc in


### PR DESCRIPTION
The `lookup_info` structures generated by `varcc` were returned as raw pointers to ocaml, which caused failures in multicore.
This fixes that by wrapping them, and returning them inside an allocated tuple.