### PR TITLE
Add WRAP_WIDTH, WRAP_MODE tags to cell_properties_text, supported since gtk 2.8

### DIFF
--- a/examples/tree.ml
+++ b/examples/tree.ml
@@ -36,8 +36,12 @@ let main () =
   let window = GWindow.window () in
   window#connect#destroy ~callback:GMain.quit;
   let view = GTree.view ~model ~packing:window#add () in
+  (* Allow wrapping for title field *)
   let col = GTree.view_column ~title:"Title" ()
-      ~renderer:(GTree.cell_renderer_text[], ["text",title]) in
+              ~renderer:(GTree.cell_renderer_text[`WRAP_WIDTH 150;
+                                                  `WRAP_MODE `WORD_CHAR],
+                         ["text",title]) in
+  col#set_resizable true;
   view#append_column col;
   let col = GTree.view_column ~title:"Author" ()
       ~renderer:(GTree.cell_renderer_text[], ["text",author]) in

--- a/src/gTree.ml
+++ b/src/gTree.ml
@@ -474,7 +474,9 @@ type cell_properties_text_only =
   | `STYLE of Pango.Tags.style
   | `TEXT of string
   | `UNDERLINE of Pango.Tags.underline
-  | `VARIANT of Pango.Tags.variant ]
+  | `VARIANT of Pango.Tags.variant
+  | `WRAP_MODE of Pango.Tags.wrap_mode
+  | `WRAP_WIDTH of int ]
 type cell_properties_text =
   [ cell_properties
   | cell_properties_text_only

--- a/src/gTree.mli
+++ b/src/gTree.mli
@@ -532,7 +532,9 @@ type cell_properties_text =
   | `TEXT of string
   | `UNDERLINE of Pango.Tags.underline
   | `VARIANT of Pango.Tags.variant
-  | `WEIGHT of Pango.Tags.weight ]
+  | `WEIGHT of Pango.Tags.weight
+  | `WRAP_MODE of Pango.Tags.wrap_mode
+  | `WRAP_WIDTH of int ]
 type cell_properties_toggle =
   [ cell_properties
   | `ACTIVATABLE of bool

--- a/src/gtkTree.props
+++ b/src/gtkTree.props
@@ -122,6 +122,8 @@ class CellRendererText vset : CellRenderer {
   "variant-set"          gboolean             : Read / Write / NoVSet
   "weight"               gint                 : Read / Write
   "weight-set"           gboolean             : Read / Write / NoVSet
+  "wrap-mode"            PangoWrapMode        : Read / Write
+  "wrap-width"           gint                 : Read / Write
   method set_fixed_height_from_font : "int -> unit"
   signal edited : GtkTreePathString string
 }

--- a/tools/propcc.ml
+++ b/tools/propcc.ml
@@ -78,7 +78,7 @@ let enums =
    ["ExtensionMode"; "WindowTypeHint"; "EventMask"; "Gravity";
     (* for canvas *)    "CapStyle"; "JoinStyle"; "LineStyle"];
    "Pango", "PangoEnums",
-   ["Stretch"; "Style"; "Underline"; "Variant"; "EllipsizeMode"];
+   ["Stretch"; "Style"; "Underline"; "Variant"; "EllipsizeMode"; "WrapMode"];
    (* GtkSourceView *)
    "Gtk", "SourceView2Enums",
    ["SourceSmartHomeEndType"; "SourceDrawSpacesFlags"];

--- a/tools/propcc.ml4
+++ b/tools/propcc.ml4
@@ -76,7 +76,7 @@ let enums = [
   [ "ExtensionMode"; "WindowTypeHint"; "EventMask"; "Gravity";
     (* for canvas *) "CapStyle"; "JoinStyle"; "LineStyle" ];
   "Pango", "PangoEnums",
-  [ "Stretch"; "Style"; "Underline"; "Variant"; "EllipsizeMode" ];
+  [ "Stretch"; "Style"; "Underline"; "Variant"; "EllipsizeMode"; "WrapMode" ];
   (* GtkSourceView *)
   "Gtk", "SourceView2Enums",
   [ "SourceSmartHomeEndType"; "SourceDrawSpacesFlags" ];


### PR DESCRIPTION
Allow text wrapping in cells in tree view.

Description of wrap-width:
https://docs.gtk.org/gtk3/property.CellRendererText.wrap-width.html

I can't figure out how to get wrap-mode to work:
https://docs.gtk.org/gtk3/property.CellRendererText.wrap-mode.html