### PR TITLE
fix broken developer.gnome.org link for docs

### DIFF
--- a/examples/pango1.ml
+++ b/examples/pango1.ml
@@ -24,7 +24,7 @@ open Cairo
 let two_pi = 2. *. acos(-1.)
 
 (* Based on the example given at
-   https://developer.gnome.org/pango/stable/pango-Cairo-Rendering.html *)
+   https://developer-old.gnome.org/pango/stable/pango-Cairo-Rendering.html *)
 let draw_text radius (cr: context) =
   let n_words = 10 in
   let font = "Sans Bold 26" in

--- a/src/cairo_pango_stubs.c
+++ b/src/cairo_pango_stubs.c
@@ -30,7 +30,7 @@
 /* OCaml Cairo bindings */
 #include "cairo_ocaml.h"
 
-/* https://developer.gnome.org/pango/stable/pango-Cairo-Rendering.html */
+/* https://developer-old.gnome.org/pango/stable/pango-Cairo-Rendering.html */
 
 #define ALLOC(name) alloc_custom(&caml_##name##_ops, sizeof(void*), 1, 50)
 

--- a/tools/gtkdoc.ml
+++ b/tools/gtkdoc.ml
@@ -20,7 +20,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let default_base_uri = "http://developer.gnome.org/gtk3/stable"
+let default_base_uri = "http://developer-old.gnome.org/gtk3/stable"
 let base_uri = ref default_base_uri
 let _ =
   Odoc_args.add_option


### PR DESCRIPTION
Links are broken in docs. New site with same API is [developer-old.gnome.org](https://developer-old.gnome.org)