### PR TITLE
GtkStyleContext: Add missing class and provider functions

### DIFF
--- a/src/gObj.ml
+++ b/src/gObj.ml
@@ -148,8 +148,15 @@ let css_provider () = new css_provider (CssProvider.create ())
 
 class style_context ctxt = object
   val ctxt = ctxt
-  (** Does not cascade!! StyleContext.add_provider_for_screen does cascade. *)
+  method as_style_context = ctxt
+  (* Does not cascade!! StyleContext.add_provider_for_screen does cascade. *)
   method add_provider (provider: css_provider) = StyleContext.add_provider ctxt (provider#as_css_provider)
+  method remove_provider (provider: css_provider) =
+    StyleContext.remove_provider ctxt provider#as_css_provider
+  method add_class cls = StyleContext.add_class ctxt cls
+  method remove_class cls = StyleContext.remove_class ctxt cls
+  method has_class cls = StyleContext.has_class ctxt cls
+  method list_classes = StyleContext.list_classes ctxt
 end
 
 class selection_input (sel : Gtk.selection_data) = object

--- a/src/gObj.mli
+++ b/src/gObj.mli
@@ -172,7 +172,13 @@ val css_provider: unit -> css_provider
 class style_context: Gtk.style_context ->
   object
     val ctxt : Gtk.style_context
+    method as_style_context : Gtk.style_context
     method add_provider: css_provider -> int -> unit
+    method remove_provider : css_provider -> unit
+    method add_class : string -> unit
+    method remove_class : string -> unit
+    method has_class : string -> bool
+    method list_classes : string list
   end
 
 (** @gtkdoc gtk gtk-Selections *)

--- a/src/gtkData.ml
+++ b/src/gtkData.ml
@@ -167,9 +167,24 @@ module StyleContext = struct
     let user : t = 800
   end
 
+  external add_provider_for_screen : Gdk.screen -> css_provider -> ProviderPriority.t -> unit
+      = "ml_gtk_style_context_add_provider_for_screen"
+  external remove_provider_for_screen : Gdk.screen -> css_provider -> unit
+      = "ml_gtk_style_context_remove_provider_for_screen"
+  external reset_widgets : Gdk.screen -> unit
+      = "ml_gtk_style_context_reset_widgets"
+
   (** Does not cascade!! *)
   external add_provider : style_context -> css_provider -> ProviderPriority.t -> unit
       = "ml_gtk_style_context_add_provider"
-  external add_provider_for_screen : Gdk.screen -> css_provider -> ProviderPriority.t -> unit
-      = "ml_gtk_style_context_add_provider_for_screen"
+  external remove_provider : style_context -> css_provider -> unit
+      = "ml_gtk_style_context_remove_provider"
+  external add_class : style_context -> string -> unit
+      = "ml_gtk_style_context_add_class"
+  external remove_class : style_context -> string -> unit
+      =  "ml_gtk_style_context_remove_class"
+  external has_class : style_context -> string -> bool
+      = "ml_gtk_style_context_has_class"
+  external list_classes : style_context -> string list
+      = "ml_gtk_style_context_list_classes"
 end

--- a/src/ml_gtk.c
+++ b/src/ml_gtk.c
@@ -222,8 +222,18 @@ CAMLprim value ml_gtk_css_provider_load_from_data(value provider, value data) {
   if (err) ml_raise_gerror(err);
   return Val_unit;
 }
-ML_3 (gtk_style_context_add_provider, GtkStyleContext_val, GtkStyleProvider_val, Int_val, Unit)
+
 ML_3 (gtk_style_context_add_provider_for_screen, GdkScreen_val, GtkStyleProvider_val, Int_val, Unit)
+ML_2 (gtk_style_context_remove_provider_for_screen, GdkScreen_val, GtkStyleProvider_val, Unit)
+ML_1 (gtk_style_context_reset_widgets, GdkScreen_val, Unit)
+
+ML_3 (gtk_style_context_add_provider, GtkStyleContext_val, GtkStyleProvider_val, Int_val, Unit)
+ML_2 (gtk_style_context_remove_provider, GtkStyleContext_val, GtkStyleProvider_val, Unit)
+ML_2 (gtk_style_context_add_class, GtkStyleContext_val, String_val, Unit)
+ML_2 (gtk_style_context_remove_class, GtkStyleContext_val, String_val, Unit)
+ML_2 (gtk_style_context_has_class, GtkStyleContext_val, String_val, Val_bool)
+CAMLprim value ml_gtk_style_context_list_classes(value ctx)
+{ return Val_GList(gtk_style_context_list_classes(GtkStyleContext_val(ctx)), Val_string); }
 
 /* gtkdata.h */
 


### PR DESCRIPTION
Add the missing methods for working with classes and providers on `style_context`. Also add missing functions operating on `screen` for working with providers.

Bindings for these functions already exist in `tools/introspection/stubs/stubs_Gtk.ml` but I'm not sure to see what that mean so I implemented them again by taking the similar functions as examples.