### PR TITLE
Add GdkEvent.Scroll.delta_{x,y}

### DIFF
--- a/src/gdkEvent.ml
+++ b/src/gdkEvent.ml
@@ -121,6 +121,8 @@ module Scroll = struct
   external device : t -> device = "ml_GdkEventScroll_device"
   external x_root : t -> float = "ml_GdkEventScroll_x_root"
   external y_root : t -> float = "ml_GdkEventScroll_y_root"
+  external delta_x : t -> float = "ml_GdkEventScroll_delta_x"
+  external delta_y : t -> float = "ml_GdkEventScroll_delta_y"
 end
 
 module Key = struct

--- a/src/ml_gdk.c
+++ b/src/ml_gdk.c
@@ -548,6 +548,8 @@ Make_Extractor (GdkEventScroll, GdkEvent_arg(Scroll),
 Make_Extractor (GdkEventScroll, GdkEvent_arg(Scroll), device, Val_GdkDevice)
 Make_Extractor (GdkEventScroll, GdkEvent_arg(Scroll), x_root, copy_double)
 Make_Extractor (GdkEventScroll, GdkEvent_arg(Scroll), y_root, copy_double)
+Make_Extractor (GdkEventScroll, GdkEvent_arg(Scroll), delta_x, copy_double)
+Make_Extractor (GdkEventScroll, GdkEvent_arg(Scroll), delta_y, copy_double)
 
 Make_Extractor (GdkEventKey, GdkEvent_arg(Key), state, Val_int)
 Make_Extractor (GdkEventKey, GdkEvent_arg(Key), keyval, Val_int)


### PR DESCRIPTION
At least on my laptop, using Wayland, GTK only generates "smooth" scroll events when using the touchpad. These fields are necessary in order to work out the direction and distance of the event.
