### PR TITLE
Fix incompatible pointer type error

### DIFF
--- a/src/wrappers.c
+++ b/src/wrappers.c
@@ -113,7 +113,7 @@ CAMLexport value Val_pointer (void *ptr)
     return ret;
 }
 
-CAMLprim value copy_string_check (const char*str)
+CAMLprim value copy_string_check (void *str)
 {
     if (!str) ml_raise_null_pointer ();
     return copy_string ((char*) str);

--- a/src/wrappers.h
+++ b/src/wrappers.h
@@ -107,7 +107,7 @@ CAMLprim value ml_some (value);
 value ml_cons (value, value);
 CAMLexport void ml_raise_null_pointer (void) Noreturn;
 CAMLexport value Val_pointer (void *);
-CAMLprim value copy_string_check (const char*);
+CAMLprim value copy_string_check (void *);
 value copy_string_or_null (const char *);
 value Val_option_string (const char *s);
 


### PR DESCRIPTION
The Fedora project is starting to build packages with a GCC 14 prerelease.  It is pickier about incompatible types than previous versions.  Building lablgtk3 3.1.4 yields this error:
```In file included from ml_gtk.c:36:
ml_gtk.c: In function ‘ml_gtk_style_context_list_classes’:
wrappers.h:422:20: error: passing argument 2 of ‘Val_GList’ from incompatible pointer type [-Wincompatible-pointer-types]
  422 | #define Val_string copy_string_check
      |                    ^~~~~~~~~~~~~~~~~
      |                    |
      |                    value (*)(const char *) {aka long int (*)(const char *)}
ml_gtk.c:236:78: note: in expansion of macro ‘Val_string’
  236 | { return Val_GList(gtk_style_context_list_classes(GtkStyleContext_val(ctx)), Val_string); }
      |                                                                              ^~~~~~~~~~
In file included from ml_gtk.c:37:
ml_glib.h:30:42: note: expected ‘value_in’ {aka ‘long int (*)(void *)’} but argument is of type ‘value (*)(const char *)’ {aka ‘long int (*)(const char *)’}
   30 | CAMLexport value Val_GList (GList *list, value_in);
      |                                          ^~~~~~~~
```

Completely unrelated, but I would also like to point out that dune-project still has `(version 3.1.2)`.