### PR TITLE
Typo in ml_gtk_text_buffer_get_iter_at_line_index

### DIFF
--- a/src/ml_gtktext.c
+++ b/src/ml_gtktext.c
@@ -366,7 +366,7 @@ CAMLprim value ml_gtk_text_buffer_get_iter_at_line_index(value tb,
 {
   CAMLparam3(tb,l,c);
   GtkTextIter res;
-  gtk_text_buffer_get_iter_at_line_offset(GtkTextBuffer_val(tb),
+  gtk_text_buffer_get_iter_at_line_index(GtkTextBuffer_val(tb),
 					  &res,
 					  Int_val(l),
 					  Int_val(c));


### PR DESCRIPTION
Hi, there seems to be a typo in the definition of `ml_gtk_text_buffer_get_iter_at_line_index` as its code refers to `gtk_text_buffer_get_iter_at_line_offset` (like in `ml_gtk_text_buffer_get_iter_at_line_offset`) while I guess `gtk_text_buffer_get_iter_at_line_index` is instead expected. I did not test the change, but we observed an utf8 issue in coqide which might be caused by this. Best, Hugo