### PR TITLE
Fixes gdk_window_clear_area and adds gdk_window_clear_area_e

### DIFF
--- a/src/gdk.ml
+++ b/src/gdk.ml
@@ -317,7 +317,10 @@ module Window = struct
   external clear : window -> unit = "ml_gdk_window_clear"
   external clear_area :
     window -> x:int -> y:int -> width:int -> height:int -> unit
-    = "ml_gdk_window_clear"
+    = "ml_gdk_window_clear_area"
+  external clear_area_e :
+    window -> x:int -> y:int -> width:int -> height:int -> unit
+    = "ml_gdk_window_clear_area_e"
   external get_xwindow : [>`drawable] obj -> xid = "ml_GDK_WINDOW_XWINDOW"
 
   let set_back_pixmap w pix = 

--- a/src/gdk.mli
+++ b/src/gdk.mli
@@ -227,6 +227,8 @@ module Window :
     val clear : window -> unit
     val clear_area :
         window -> x:int -> y:int -> width:int -> height:int -> unit
+    val clear_area_e :
+        window -> x:int -> y:int -> width:int -> height:int -> unit
     val get_xwindow : [>`drawable] obj -> xid
     val native_of_xid : xid -> native_window
     val xid_of_native : native_window -> xid

--- a/src/ml_gdk.c
+++ b/src/ml_gdk.c
@@ -270,6 +270,8 @@ ML_2 (gdk_window_set_cursor, GdkWindow_val, GdkCursor_val, Unit)
 ML_1 (gdk_window_clear, GdkWindow_val, Unit)
 ML_5 (gdk_window_clear_area, GdkWindow_val, Int_val, Int_val, Int_val, Int_val,
       Unit)
+ML_5 (gdk_window_clear_area_e, GdkWindow_val, Int_val, Int_val, Int_val, Int_val,
+      Unit)
 ML_0 (GDK_ROOT_PARENT, Val_GdkWindow)
 ML_1 (gdk_window_get_parent, GdkWindow_val, Val_GdkWindow)
 ML_2 (gdk_window_set_transient_for, GdkWindow_val, GdkWindow_val, Unit)


### PR DESCRIPTION
I found `Gdk.Window.clear_area` is bound to a wrong C function `ml_gdk_window_clear`.

This PR fixes this bug and add its variant `Gdk.Window.clear_area_e` for `gdk_window_clear_area_e`.
