### PR TITLE
Fix path handling from dune variable

### DIFF
--- a/tools/introspection/propcc.ml
+++ b/tools/introspection/propcc.ml
@@ -557,7 +557,7 @@ let outfile = ref ""
 let ooutfile = ref ""
   
 let process_file f =
-  let base = Filename.chop_extension f in
+  let base = Filename.chop_extension (Filename.basename f) in
   let baseM = String.capitalize_ascii base
   in
     (* Input *)

--- a/tools/introspection/propcc.ml4
+++ b/tools/introspection/propcc.ml4
@@ -288,7 +288,7 @@ let outfile = ref ""
 let ooutfile = ref ""
 
 let process_file f =
-  let base = Filename.chop_extension f in
+  let base = Filename.chop_extension (Filename.basename f) in
   let baseM = String.capitalize_ascii base in
   prefix := baseM;
   (* Input *)

--- a/tools/propcc.ml
+++ b/tools/propcc.ml
@@ -549,7 +549,7 @@ let outfile = ref ""
 let ooutfile = ref ""
 
 let process_file f =
-  let base = Filename.chop_extension f in
+  let base = Filename.chop_extension (Filename.basename f) in
   let baseM = String.capitalize_ascii base in
   prefix := baseM;
   (* Input *)

--- a/tools/propcc.ml4
+++ b/tools/propcc.ml4
@@ -289,7 +289,7 @@ let outfile = ref ""
 let ooutfile = ref ""
 
 let process_file f =
-  let base = Filename.chop_extension f in
+  let base = Filename.chop_extension (Filename.basename f) in
   let baseM = String.capitalize_ascii base in
   prefix := baseM;
   (* Input *)


### PR DESCRIPTION
Dune `deps` variables are expanded to paths. The representation of this has changed with https://github.com/ocaml/dune/pull/15156, causing propcc to fail on the pending dune 3.24: a `%{dep:gtkAction.props}` referencing a file in the rule's own directory now expands to "./gtkAction.props", and propcc derived its secondary output filename by naively string-prepending "o" to the input, yielding "o./gtkActionProps.ml", which is an invalid path that crashes `open_out`.

To fix, we take the basename of the input as the stable seed for the derived output filenames.